### PR TITLE
Use constants from libc where they exist

### DIFF
--- a/src/c/netlink.c
+++ b/src/c/netlink.c
@@ -5,56 +5,6 @@
 
 const uint8_t nla_alignto = NLA_ALIGNTO;
 
-const uint32_t netlink_route = NETLINK_ROUTE;
-const uint32_t netlink_unused = NETLINK_UNUSED;
-const uint32_t netlink_usersock = NETLINK_USERSOCK;
-const uint32_t netlink_firewall = NETLINK_FIREWALL;
-const uint32_t netlink_sock_diag = NETLINK_SOCK_DIAG;
-const uint32_t netlink_nflog = NETLINK_NFLOG;
-const uint32_t netlink_xfrm = NETLINK_XFRM;
-const uint32_t netlink_selinux = NETLINK_SELINUX;
-const uint32_t netlink_iscsi = NETLINK_ISCSI;
-const uint32_t netlink_audit = NETLINK_AUDIT;
-const uint32_t netlink_fib_lookup = NETLINK_FIB_LOOKUP;
-const uint32_t netlink_connector = NETLINK_CONNECTOR;
-const uint32_t netlink_netfilter = NETLINK_NETFILTER;
-const uint32_t netlink_ip6_fw = NETLINK_IP6_FW;
-const uint32_t netlink_dnrtmsg = NETLINK_DNRTMSG;
-const uint32_t netlink_kobject_uevent = NETLINK_KOBJECT_UEVENT;
-const uint32_t netlink_generic = NETLINK_GENERIC;
-const uint32_t netlink_scsitransport = NETLINK_SCSITRANSPORT;
-const uint32_t netlink_ecryptfs = NETLINK_ECRYPTFS;
-const uint32_t netlink_rdma = NETLINK_RDMA;
-const uint32_t netlink_crypto = NETLINK_CRYPTO;
-
-const uint16_t nlmsg_noop = NLMSG_NOOP;
-const uint16_t nlmsg_error = NLMSG_ERROR;
-const uint16_t nlmsg_done = NLMSG_DONE;
-const uint16_t nlmsg_overrun = NLMSG_OVERRUN;
-
-const uint16_t nlm_f_request = NLM_F_REQUEST;
-const uint16_t nlm_f_multi = NLM_F_MULTI;
-const uint16_t nlm_f_ack = NLM_F_ACK;
-const uint16_t nlm_f_echo = NLM_F_ECHO;
-const uint16_t nlm_f_dump_intr = NLM_F_DUMP_INTR;
-
-// To fix linking error for older versions of netlink
-#ifdef NLM_F_DUMP_FILTERED
-const uint16_t nlm_f_dump_filtered = NLM_F_DUMP_FILTERED;
-#else
-const uint16_t nlm_f_dump_filtered = 32;
-#endif
-
-const uint16_t nlm_f_root = NLM_F_ROOT;
-const uint16_t nlm_f_match = NLM_F_MATCH;
-const uint16_t nlm_f_atomic = NLM_F_ATOMIC;
-const uint16_t nlm_f_dump = NLM_F_DUMP;
-
-const uint16_t nlm_f_replace = NLM_F_REPLACE;
-const uint16_t nlm_f_excl = NLM_F_EXCL;
-const uint16_t nlm_f_create = NLM_F_CREATE;
-const uint16_t nlm_f_append = NLM_F_APPEND;
-
 const uint8_t ctrl_cmd_unspec = CTRL_CMD_UNSPEC;
 const uint8_t ctrl_cmd_newfamily = CTRL_CMD_NEWFAMILY;
 const uint8_t ctrl_cmd_delfamily = CTRL_CMD_DELFAMILY;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,21 @@ impl Nl for u32 {
     }
 }
 
+impl Nl for i32 {
+    fn serialize(&mut self, state: &mut NlSerState) -> Result<(), SerError> {
+        try!(state.0.write_i32::<NativeEndian>(*self));
+        Ok(())
+    }
+
+    fn deserialize(state: &mut NlDeState) -> Result<Self, DeError> {
+        Ok(try!(state.0.read_i32::<NativeEndian>()))
+    }
+
+    fn size(&self) -> usize {
+        mem::size_of::<i32>()
+    }
+}
+
 impl Nl for Vec<u8> {
     fn serialize(&mut self, state: &mut NlSerState) -> Result<(), SerError> {
         let len = state.get_usize().unwrap_or(self.len());

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -25,9 +25,8 @@ pub struct NlSocket {
 impl NlSocket {
     /// Wrapper around `socket()` syscall filling in the netlink-specific information
     pub fn new(proto: NlFamily) -> Result<Self, io::Error> {
-        let proto_u32: u32 = proto.into();
         let fd = match unsafe {
-            libc::socket(libc::AF_NETLINK, libc::SOCK_RAW, proto_u32 as libc::c_int)
+            libc::socket(libc::AF_NETLINK, libc::SOCK_RAW, proto.into())
         } {
             i if i >= 0 => Ok(i),
             _ => Err(io::Error::last_os_error()),


### PR DESCRIPTION
Hi. I'm writing a wrapper for `libnftnl` in Rust to be able to control the Linux firewall. To do that I need to talk netlink. Since `libnftnl` uses `libmnl` for that natively I could just write a wrapper for `libmnl` as well. But the more pure-rust I can use the better was my thought. And it also feels like there are already too many libraries duplicating the `NlFamily` enum. So I looked for pure Rust netlink libraries.

After looking at yours for a while I see that many of the constants you declare are already in libc. So I thought I could try to make it use them instead. I don't know if you want this change or not, but it reduces duplication at least. We could quite likely get the remaining constants merged into libc as well, I have had constants from for example `<linux/netfilter/*>` merged before.

I had to do a little trick with the macro there to get rid of unnecessary `unsafe` warnings since there are now both safe and unsafe usages of that macro. But it turned out quite OK. Can be simplified again if all constants become safe as well.