### PR TITLE
Make serialize work without mutating input

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -40,6 +40,13 @@ impl Error for NlError {
 #[derive(Debug)]
 pub struct SerError(String);
 
+impl SerError {
+    /// Create a new error with the given message as description
+    pub fn new<T: ToString>(msg: T) -> Self {
+        SerError(msg.to_string())
+    }
+}
+
 try_err_compat!(SerError, io::Error);
 
 impl Display for SerError {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -61,7 +61,7 @@ macro_rules! impl_var {
         }
 
         impl Nl for $name {
-            fn serialize(&mut self, state: &mut NlSerState) -> Result<(), SerError> {
+            fn serialize(&self, state: &mut NlSerState) -> Result<(), SerError> {
                 let mut v: $ty = self.clone().into();
                 try!(Nl::serialize(&mut v, state));
                 Ok(())

--- a/src/genlhdr.rs
+++ b/src/genlhdr.rs
@@ -48,7 +48,7 @@ impl Default for GenlHdr {
 }
 
 impl Nl for GenlHdr {
-    fn serialize(&mut self, state: &mut NlSerState) -> Result<(), SerError> {
+    fn serialize(&self, state: &mut NlSerState) -> Result<(), SerError> {
         self.cmd.serialize(state)?;
         self.version.serialize(state)?;
         self.reserved.serialize(state)?;
@@ -83,7 +83,7 @@ mod test {
         let attr = vec![NlAttrHdr::new_binary_payload(None, CtrlAttr::FamilyId,
                                                         vec![0, 1, 2, 3, 4, 5, 0, 0]
                                                       )];
-        let mut genl = GenlHdr::new(CtrlCmd::Getops, 2,
+        let genl = GenlHdr::new(CtrlCmd::Getops, 2,
                                     attr).unwrap();
         let mut state = NlSerState::new();
         genl.serialize(&mut state).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ impl Nl for String {
     }
 
     fn size(&self) -> usize {
-        self.len()
+        self.len() + 1
     }
 }
 
@@ -305,7 +305,9 @@ mod test {
         let s = "AAAAA".to_string();
         let mut state = NlSerState::new();
         s.serialize(&mut state).unwrap();
-        assert_eq!(vec![65, 65, 65, 65, 65, 0], state.into_inner().as_slice());
+        let serialized = state.into_inner();
+        assert_eq!(vec![65, 65, 65, 65, 65, 0], serialized.as_slice());
+        assert_eq!(Nl::size(&s), serialized.len());
 
         let s = &[65, 65, 65, 65, 65, 65, 65, 0, 0, 0, 0];
         let mut state = NlDeState::new(s);

--- a/src/nlhdr.rs
+++ b/src/nlhdr.rs
@@ -50,10 +50,10 @@ impl<I: Default, T: Default> Default for NlHdr<I, T> {
 }
 
 impl<I: Default + Nl, T: Nl> Nl for NlHdr<I, T> {
-    fn serialize(&mut self, state: &mut NlSerState) -> Result<(), SerError> {
+    fn serialize(&self, state: &mut NlSerState) -> Result<(), SerError> {
         try!(self.nl_len.serialize(state));
         try!(self.nl_type.serialize(state));
-        let mut val = self.nl_flags.iter().fold(0, |acc: u16, val| {
+        let val = self.nl_flags.iter().fold(0, |acc: u16, val| {
             let v: u16 = val.clone().into();
             acc | v
         });
@@ -124,7 +124,7 @@ impl<T> NlAttrHdr<T> where T: Nl {
     }
 
     /// Create new netlink attribute payload from string, handling null byte termination
-    pub fn new_string_payload(nla_len: Option<u16>, nla_type: T, mut string_payload: String)
+    pub fn new_string_payload(nla_len: Option<u16>, nla_type: T, string_payload: String)
             -> Result<Self, SerError> {
         let mut nla = NlAttrHdr::default();
         nla.nla_type = nla_type;
@@ -154,7 +154,7 @@ impl<T> Default for NlAttrHdr<T> where T: Default {
 }
 
 impl<T> Nl for NlAttrHdr<T> where T: Default + Nl {
-    fn serialize(&mut self, state: &mut NlSerState) -> Result<(), SerError> {
+    fn serialize(&self, state: &mut NlSerState) -> Result<(), SerError> {
         self.nla_len.serialize(state)?;
         self.nla_type.serialize(state)?;
         state.set_usize(self.payload.asize());
@@ -270,7 +270,7 @@ impl Default for NlEmpty {
 }
 
 impl Nl for NlEmpty {
-    fn serialize(&mut self, _state: &mut NlSerState) -> Result<(), SerError> {
+    fn serialize(&self, _state: &mut NlSerState) -> Result<(), SerError> {
         Ok(())
     }
 
@@ -293,7 +293,7 @@ mod test {
     #[test]
     fn test_nlhdr_serialize() {
         let mut state = NlSerState::new();
-        let mut nl = NlHdr::<Nlmsg, NlEmpty>::new(None, Nlmsg::Noop,
+        let nl = NlHdr::<Nlmsg, NlEmpty>::new(None, Nlmsg::Noop,
                                                    Vec::new(), None, None, NlEmpty);
         nl.serialize(&mut state).unwrap();
         let s: &mut [u8] = &mut [0; 16];

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -87,7 +87,7 @@ impl NlSocket {
     }
 
     /// Serialize and send Rust `NlMsg` type
-    pub fn sendmsg<I: Nl, T: Nl>(&mut self, mut msg: NlHdr<I, T>, flags: i32)
+    pub fn sendmsg<I: Nl, T: Nl>(&mut self, msg: NlHdr<I, T>, flags: i32)
                                         -> Result<isize, NlError> {
         let mut state = NlSerState::new();
         try!(msg.serialize(&mut state));


### PR DESCRIPTION
I noticed `self.push('\0');` in the serialization of `String`. I personally found it to be a strange property that serializing a type could possibly modify it. Because serializing the same instance multiple times could then yield different results. In the case of `String`, calling `Nl::size` on a `String` would differ before and after the serialization.

Here I make `&mut self` into `&self` in `Nl::serialize` to prohibit mutation of `self`. The only type affected by this was indeed `String`, which I solved by re-allocating the string buffer into one with the terminating null in the serialization implementation.

I was also looking into making the `deserialize` impl for `String` make use of `CString`. But I was not really sure how the lengths of the deserialization state worked. Especially this line:
```rust
let input = state.get_usize().unwrap_or(state.0.get_ref().len());
```