### PR TITLE
Created `impl Nl for u64`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,10 @@ use err::{SerError,DeError};
 /// Max supported message length for netlink messages supported by the kernel
 pub const MAX_NL_LENGTH: usize = 32768;
 
-/// Trait defining basic actions required for netlink communication
+/// Trait defining basic actions required for netlink communication.
+/// Implementations for basic and `neli`'s types are provided (see below). Create new
+/// implementations if you have to work with a Netlink API that uses
+/// values of more unusual types.
 pub trait Nl: Sized {
     /// Serialization input type for stateful serialization - set to `()` for stateless
     /// serialization


### PR DESCRIPTION
One of the common types found when dealing with Generic Netlink is `u64`. This PR adds an implementation of the `Nl` trait for `u64` so that these values can be easily deserialized by `neli` when reading Netlink messages.

You can use the new `impl` to parse Netlink attrs link this:
```
    let peer_attr_handle: neli::nlattr::AttrHandle<'_, u16> = ...;
    let recieved_bytes: u64 = peer_attr_handle.get_payload_with::<u64>(PEER_RECIEVED_BYES_ATTR, None).unwrap();
```

The implementation is defined in basically the same way as the other impls for unsigned integers are. 
A test that works like the others was also added to `src/lib.rs`.

This pr addresses #11.