### PR TITLE
Updated `consts` for better documentation

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -105,7 +105,7 @@ macro_rules! impl_var_base {
 /// # Usage
 ///  Create an `enum` named "MyNetlinkProtoAttrs" that can be serialized into `u16`s to use with Netlink.
 ///  Possibly represents the fields on a message you recieved from Netlink.
-///  ```
+///  ```ignore
 ///  impl_var!(MyNetlinkProtoAttrs, u16,
 ///     Id => 16 as u16,
 ///     Name => 17 as u16,
@@ -113,7 +113,7 @@ macro_rules! impl_var_base {
 ///  );
 /// ```
 /// Or, with doc comments (if you're developing a library)
-/// ```
+/// ```ignore
 ///  impl_var!(
 ///     /// These are the attributes returned
 ///     /// by a fake netlink protocol.

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -40,6 +40,8 @@ use Nl;
 
 // This is to facillitate the two different ways to call
 // `impl_var`: one with doc comments and one without.
+#[macro_export]
+#[doc(hidden)]
 macro_rules! impl_var_base {
     ($name:ident, $ty:ty, $var_def:ident => $val_def:expr,
       $( $var:ident => $val:expr ),* ) => {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,21 +1,12 @@
 //! # High level notes
 //!
-//! There are a few important things to note in this module.
+//! The items in this module are created by macros, which give them the traits necessary to be
+//! serialized into Netlink compatible types. The macros are exported - you can use them too!
+//! See `impl_var`, `impl_trait`, and `impl_var_trait`.
 //!
-//! * The macros are exported - you can use them too!
-//!   * `impl_var` is for naming a new enum, passing in what type it serializes to and deserializes
-//!     from, and providing a mapping from variants to expressions (such as libc consts) that
-//!     will ultimately be used in the serialization/deserialization step when sending the netlink
-//!     message over the wire.
-//!   * `impl_var_trait` is for flagging a new enum as usable in a field that is a generic type.
-//!     This way, the type can be constrained when the impl is provided to only accept enums that
-//!     implement the marker trait that corresponds to the given marker trait. The current
-//!     convention is to use `impl_trait` to create the trait with the name of the field that
-//!     is the generic type and then use `impl_var_trait` to flag the new enum as usable in
-//!     this field. See the examples below for more details.
-//!   * `impl_trait` is for implementing a marker trait with the appropriate trait constraints
-//!     on the newly implemented trait. It accepts a name and a type for serialization and
-//!     deserialization conversions.
+//! Note that most of these constants come from the Linux kernel headers, which can be found
+//! in `/usr/include/linux` on many distros. You can also see `man 3 netlink`, `man 7 netlink`,
+//! and `man 7 rtnetlink` for more information.
 //!
 //! # Design decisions
 //!
@@ -40,30 +31,18 @@
 //!   and if you are sure that it is correct, you can use it. If it is a garbage value, this can
 //!   also be useful for error reporting.
 
+use buffering::copy::{StreamReadBuffer, StreamWriteBuffer};
+use libc;
 use std::mem;
 
-use buffering::copy::{StreamReadBuffer,StreamWriteBuffer};
-use libc;
-
+use err::{DeError, SerError};
 use Nl;
-use err::{SerError,DeError};
 
-#[macro_export]
-macro_rules! impl_var {
-    ( $name:ident, $ty:ty, $var_def:ident => $val_def:expr,
-      $( $var:ident => $val:expr ),* ) => (
-        /// Enum representing C constants for netlink packets
-        #[derive(Clone,Debug,Eq,PartialEq)]
-        pub enum $name {
-            #[allow(missing_docs)]
-            $var_def,
-            $(
-                #[allow(missing_docs)]
-                $var,
-            )*
-            /// Variant that signifies an invalid value while deserializing
-            UnrecognizedVariant($ty),
-        }
+// This is to facillitate the two different ways to call
+// `impl_var`: one with doc comments and one without.
+macro_rules! impl_var_base {
+    ($name:ident, $ty:ty, $var_def:ident => $val_def:expr,
+      $( $var:ident => $val:expr ),* ) => {
 
         impl From<$ty> for $name {
             fn from(v: $ty) -> Self {
@@ -114,22 +93,115 @@ macro_rules! impl_var {
                 mem::size_of::<$ty>()
             }
         }
+    };
+}
+
+#[macro_export]
+/// For naming a new enum, passing in what type it serializes to and deserializes
+/// from, and providing a mapping from variants to expressions (such as libc consts) that
+/// will ultimately be used in the serialization/deserialization step when sending the netlink
+/// message over the wire.
+///
+/// # Usage
+///  Create an `enum` named "MyNetlinkProtoAttrs" that can be serialized into `u16`s to use with Netlink.
+///  Possibly represents the fields on a message you recieved from Netlink.
+///  ```
+///  impl_var!(MyNetlinkProtoAttrs, u16,
+///     Id => 16 as u16,
+///     Name => 17 as u16,
+///     Size => 18 as u16
+///  );
+/// ```
+/// Or, with doc comments (if you're developing a library)
+/// ```
+///  impl_var!(
+///     /// These are the attributes returned
+///     /// by a fake netlink protocol.
+///     ( MyNetlinkProtoAttrs, u16,
+///     Id => 16 as u16,
+///     Name => 17 as u16,
+///     Size => 18 as u16 )
+///  );
+/// ```
+///
+macro_rules! impl_var {
+    (  $(#[$outer:meta])*
+      ($name:ident, $ty:ty, $var_def:ident => $val_def:expr,
+      $( $var:ident => $val:expr ),* )) => ( // with comments
+        $(#[$outer])*
+        #[derive(Clone,Debug,Eq,PartialEq)]
+        pub enum $name {
+            #[allow(missing_docs)]
+            $var_def,
+            $(
+                #[allow(missing_docs)]
+                $var,
+            )*
+            /// Variant that signifies an invalid value while deserializing
+            UnrecognizedVariant($ty),
+        }
+
+        impl_var_base!($name, $ty, $var_def => $val_def,
+            $( $var => $val),*
+        );
+    );
+    ($name:ident, $ty:ty, $var_def:ident => $val_def:expr,
+      $( $var:ident => $val:expr ),* ) => ( // without comments
+        #[allow(missing_docs)]
+        #[derive(Clone,Debug,Eq,PartialEq)]
+        pub enum $name {
+            #[allow(missing_docs)]
+            $var_def,
+            $(
+                #[allow(missing_docs)]
+                $var,
+            )*
+            /// Variant that signifies an invalid value while deserializing
+            UnrecognizedVariant($ty),
+        }
+
+        impl_var_base!($name, $ty, $var_def => $val_def,
+            $( $var => $val),*
+        );
     );
 }
 
 #[macro_export]
+/// For flagging a new enum as usable in a field that is a generic type.
+/// This way, the type can be constrained when the impl is provided to only accept enums that
+/// implement the marker trait that corresponds to the given marker trait. The current
+/// convention is to use `impl_trait` to create the trait with the name of the field that
+/// is the generic type and then use `impl_var_trait` to flag the new enum as usable in
+/// this field. See the examples below for more details.
 macro_rules! impl_trait {
-    ( $trait_name:ident, $to_from_ty:ty ) => (
+    ( $(#[$outer:meta])*
+    ( $trait_name:ident, $to_from_ty:ty )) => { // with comments
+        $(#[$outer])*
+        pub trait $trait_name: Nl + From<$to_from_ty> + Into<$to_from_ty> {}
+    };
+    ( $trait_name:ident, $to_from_ty:ty ) => { // without comments
         #[allow(missing_docs)]
         pub trait $trait_name: Nl + From<$to_from_ty> + Into<$to_from_ty> {}
-    );
+    };
 }
 
 #[macro_export]
+/// For implementing a marker trait with the appropriate trait constraints
+/// on the newly implemented trait. It accepts a name and a type for serialization and
+/// deserialization conversions.
 macro_rules! impl_var_trait {
+    ( $(#[$outer:meta])*
     ( $name:ident, $ty:ty, $impl_name:ident, $var_def:ident => $val_def:expr,
-      $( $var:ident => $val:expr ),* ) => (
-        impl_var!( $name, $ty, $var_def => $val_def, $( $var => $val ),* );
+      $( $var:ident => $val:expr ),* )) => ( // with comments
+        impl_var!( $(#[$outer])*
+            ($name, $ty, $var_def => $val_def, $( $var => $val ),* )
+        );
+
+        impl $impl_name for $name {}
+    );
+    ( $name:ident, $ty:ty, $impl_name:ident, $var_def:ident => $val_def:expr,
+      $( $var:ident => $val:expr ),* ) => ( // without comments
+        impl_var!($name, $ty, $var_def => $val_def, $( $var => $val ),* );
 
         impl $impl_name for $name {}
     );
@@ -140,14 +212,16 @@ pub fn alignto(len: usize) -> usize {
     (len + libc::NLA_ALIGNTO as usize - 1) & !(libc::NLA_ALIGNTO as usize - 1)
 }
 
-/// Address families
-impl_var!(Af, libc::c_uchar,
+impl_var!(
+    /// Address families 
+    ( Af, libc::c_uchar,
     Inet => libc::AF_INET as libc::c_uchar,
-    Inet6 => libc::AF_INET6 as libc::c_uchar
+    Inet6 => libc::AF_INET6 as libc::c_uchar )
 );
 
-/// Address families for sockets
-impl_var!(AddrFamily, libc::c_int,
+impl_var!(
+    /// Address families for sockets
+    (  AddrFamily, libc::c_int,
     UnixOrLocal => libc::AF_UNIX,
     Inet => libc::AF_INET,
     Inet6 => libc::AF_INET6,
@@ -158,10 +232,12 @@ impl_var!(AddrFamily, libc::c_int,
     Atmpvc => libc::AF_ATMPVC,
     Appletalk => libc::AF_APPLETALK,
     Packet => libc::AF_PACKET,
-    Alg => libc::AF_ALG
+    Alg => libc::AF_ALG )
 );
 
-impl_var!(IfaF, u32,
+impl_var!(
+    /// Interface address flags.
+    ( IfaF, u32,
     Secondary => libc::IFA_F_SECONDARY,
     Temporary => libc::IFA_F_TEMPORARY,
     Nodad => libc::IFA_F_NODAD,
@@ -174,10 +250,13 @@ impl_var!(IfaF, u32,
     Managetempaddr => libc::IFA_F_MANAGETEMPADDR,
     Noprefixroute => libc::IFA_F_NOPREFIXROUTE,
     Mcautojoin => libc::IFA_F_MCAUTOJOIN,
-    StablePrivacy => libc::IFA_F_STABLE_PRIVACY
+    StablePrivacy => libc::IFA_F_STABLE_PRIVACY )
 );
 
-impl_var!(Rtn, libc::c_uchar,
+impl_var!(
+    /// `rtm_type`
+    /// The results of a lookup from a route table
+    ( Rtn, libc::c_uchar,
     Unspec => libc::RTN_UNSPEC,
     Unicast => libc::RTN_UNICAST,
     Local => libc::RTN_LOCAL,
@@ -189,43 +268,57 @@ impl_var!(Rtn, libc::c_uchar,
     Prohibit => libc::RTN_PROHIBIT,
     Throw => libc::RTN_THROW,
     Nat => libc::RTN_NAT,
-    Xresolve => libc::RTN_XRESOLVE
+    Xresolve => libc::RTN_XRESOLVE)
 );
 
-impl_var!(Rtprot, libc::c_uchar,
+impl_var!(
+    /// `rtm_protocol`
+    /// The origins of routes that are defined in the kernel
+    ( Rtprot, libc::c_uchar,
     Unspec => libc::RTPROT_UNSPEC,
     Redirect => libc::RTPROT_REDIRECT,
     Kernel => libc::RTPROT_KERNEL,
     Boot => libc::RTPROT_BOOT,
-    Static => libc::RTPROT_STATIC
+    Static => libc::RTPROT_STATIC )
 );
 
-impl_var!(RtScope, libc::c_uchar,
+impl_var!(
+    /// `rtm_scope`
+    /// The distance between destinations
+    ( RtScope, libc::c_uchar,
     Universe => libc::RT_SCOPE_UNIVERSE,
     Site => libc::RT_SCOPE_SITE,
     Link => libc::RT_SCOPE_LINK,
     Host => libc::RT_SCOPE_HOST,
-    Nowhere => libc::RT_SCOPE_NOWHERE
+    Nowhere => libc::RT_SCOPE_NOWHERE )
 );
 
-impl_var!(RtTable, libc::c_uchar,
+impl_var!(
+    /// `rt_class_t`
+    /// Reserved route table identifiers
+    ( RtTable, libc::c_uchar,
     Unspec => libc::RT_TABLE_UNSPEC,
     Compat => libc::RT_TABLE_COMPAT,
     Default => libc::RT_TABLE_DEFAULT,
     Main => libc::RT_TABLE_MAIN,
-    Local => libc::RT_TABLE_LOCAL
+    Local => libc::RT_TABLE_LOCAL )
 );
 
-impl_var!(RtmF, libc::c_uint,
+impl_var!(
+    /// `rtm_flags`
+    /// Flags for rnetlink messages
+    ( RtmF, libc::c_uint,
     Notify => libc::RTM_F_NOTIFY,
     Cloned => libc::RTM_F_CLONED,
     Equalize => libc::RTM_F_EQUALIZE,
     Prefix => libc::RTM_F_PREFIX,
     LookupTable => libc::RTM_F_LOOKUP_TABLE,
-    FibMatch => libc::RTM_F_FIB_MATCH
+    FibMatch => libc::RTM_F_FIB_MATCH )
 );
 
-impl_var!(Nud, u16,
+impl_var!(
+    /// Arp neighbor cache entry states
+    ( Nud, u16,
     None => libc::NUD_NONE,
     Incomplete => libc::NUD_INCOMPLETE,
     Reachable => libc::NUD_REACHABLE,
@@ -234,24 +327,27 @@ impl_var!(Nud, u16,
     Probe => libc::NUD_PROBE,
     Failed => libc::NUD_FAILED,
     Noarp => libc::NUD_NOARP,
-    Permanent => libc::NUD_PERMANENT
+    Permanent => libc::NUD_PERMANENT )
 );
 
-impl_var!(Ntf, u8,
+impl_var!(
+    /// Arg neighbor cache entry flags
+    ( Ntf, u8,
     Use => libc::NTF_USE,
     Self_ => libc::NTF_SELF,
     Master => libc::NTF_MASTER,
     Proxy => libc::NTF_PROXY,
     ExtLearned => libc::NTF_EXT_LEARNED,
     Offloaded => libc::NTF_OFFLOADED,
-    Router => libc::NTF_ROUTER
+    Router => libc::NTF_ROUTER )
 );
 
-/// Marker trait for `RtAttr.rta_type` field
-impl_trait!(RtaType, libc::c_ushort);
+impl_trait!(/// Marker trait for `RtAttr.rta_type` field
+(RtaType, libc::c_ushort));
 
-/// Enum for use with `RtAttr.rta_type`
-impl_var_trait!(Ifla, libc::c_ushort, RtaType,
+impl_var_trait!(
+    /// Enum for use with `RtAttr.rta_type`
+    ( Ifla, libc::c_ushort, RtaType,
     Unspec => libc::IFLA_UNSPEC,
     Address => libc::IFLA_ADDRESS,
     Broadcast => libc::IFLA_BROADCAST,
@@ -259,11 +355,12 @@ impl_var_trait!(Ifla, libc::c_ushort, RtaType,
     Mtu => libc::IFLA_MTU,
     Link => libc::IFLA_LINK,
     Qdisc => libc::IFLA_QDISC,
-    Stats => libc::IFLA_STATS
+    Stats => libc::IFLA_STATS )
 );
 
-/// Enum for use with `RtAttr.rta_type`
-impl_var_trait!(Ifa, libc::c_ushort, RtaType,
+impl_var_trait!(
+    /// Enum for use with `RtAttr.rta_type`
+    ( Ifa, libc::c_ushort, RtaType,
     Unspec => libc::IFA_UNSPEC,
     Address => libc::IFA_ADDRESS,
     Local => libc::IFA_LOCAL,
@@ -272,11 +369,13 @@ impl_var_trait!(Ifa, libc::c_ushort, RtaType,
     Anycast => libc::IFA_ANYCAST,
     Cacheinfo => libc::IFA_CACHEINFO,
     Multicast => libc::IFA_MULTICAST,
-    Flags => libc::IFA_FLAGS
+    Flags => libc::IFA_FLAGS )
 );
 
-/// Enum for use with `RtAttr.rta_type`
-impl_var_trait!(Rta, libc::c_ushort, RtaType,
+impl_var_trait!(
+    /// Enum for use with `RtAttr.rta_type`. 
+    /// Values are routing message attributes
+    ( Rta, libc::c_ushort, RtaType,
     Unspec => libc::RTA_UNSPEC,
     Dst => libc::RTA_DST,
     Src => libc::RTA_SRC,
@@ -287,11 +386,11 @@ impl_var_trait!(Rta, libc::c_ushort, RtaType,
     Prefsrc => libc::RTA_PREFSRC,
     Metrics => libc::RTA_METRICS,
     Multipath => libc::RTA_MULTIPATH,
-    Protoinfo => libc::RTA_PROTOINFO,
+    Protoinfo => libc::RTA_PROTOINFO, // no longer used in Linux
     Flow => libc::RTA_FLOW,
     Cacheinfo => libc::RTA_CACHEINFO,
-    Session => libc::RTA_SESSION,
-    MpAlgo => libc::RTA_MP_ALGO,
+    Session => libc::RTA_SESSION, // no longer used in Linux
+    MpAlgo => libc::RTA_MP_ALGO, // no longer used in Linux
     Table => libc::RTA_TABLE,
     Mark => libc::RTA_MARK,
     MfcStats => libc::RTA_MFC_STATS,
@@ -303,11 +402,12 @@ impl_var_trait!(Rta, libc::c_ushort, RtaType,
     Expires => libc::RTA_EXPIRES,
     Pad => libc::RTA_PAD,
     Uid => libc::RTA_UID,
-    TtlPropagate => libc::RTA_TTL_PROPAGATE
+    TtlPropagate => libc::RTA_TTL_PROPAGATE)
 );
 
-/// Interface types
-impl_var!(Arphrd, libc::c_ushort,
+impl_var!(
+    /// Interface types
+    ( Arphrd, libc::c_ushort,
     Netrom => libc::ARPHRD_NETROM,
     Ether => libc::ARPHRD_ETHER,
     Eether => libc::ARPHRD_EETHER,
@@ -328,10 +428,11 @@ impl_var!(Arphrd, libc::c_ushort,
 
     Void => libc::ARPHRD_VOID,
     None => libc::ARPHRD_NONE
-);
+));
 
-/// Values for `ifi_flags` in `rtnl.rs`
-impl_var!(Iff, libc::c_uint,
+impl_var!(
+    /// Values for `ifi_flags` in `rtnl.rs`
+    ( Iff, libc::c_uint,
     Up => libc::IFF_UP as libc::c_uint,
     Broadcast => libc::IFF_BROADCAST as libc::c_uint,
     Debug => libc::IFF_DEBUG as libc::c_uint,
@@ -353,10 +454,12 @@ impl_var!(Iff, libc::c_uint,
     Echo => libc::IFF_ECHO as libc::c_uint
 
     // Possibly more types here - need to look into private flags for interfaces
+    )
 );
 
-/// Values for `nl_family` in `NlSocket`
-impl_var!(NlFamily, libc::c_int,
+impl_var!(
+    /// Values for `nl_family` in `NlSocket`
+    ( NlFamily, libc::c_int,
     Route => libc::NETLINK_ROUTE,
     Unused => libc::NETLINK_UNUSED,
     Usersock => libc::NETLINK_USERSOCK,
@@ -377,29 +480,34 @@ impl_var!(NlFamily, libc::c_int,
     Scsitransport => libc::NETLINK_SCSITRANSPORT,
     Ecryptfs => libc::NETLINK_ECRYPTFS,
     Rdma => libc::NETLINK_RDMA,
-    Crypto => libc::NETLINK_CRYPTO
+    Crypto => libc::NETLINK_CRYPTO )
 );
 
-/// Trait marking constants valid for use in `Nlmsghdr.nl_type`
-impl_trait!(NlType, u16);
+impl_trait!(
+    /// Trait marking constants valid for use in `Nlmsghdr.nl_type`
+    (NlType, u16)
+);
 
-/// Values for `nl_type` in `Nlmsghdr`
-impl_var_trait!(Nlmsg, u16, NlType,
+impl_var_trait!(
+    /// Values for `nl_type` in `Nlmsghdr`
+    ( Nlmsg, u16, NlType,
     Noop => libc::NLMSG_NOOP as u16,
     Error => libc::NLMSG_ERROR as u16,
     Done => libc::NLMSG_DONE as u16,
-    Overrun => libc::NLMSG_OVERRUN as u16
+    Overrun => libc::NLMSG_OVERRUN as u16)
 );
 
-/// Values for `nl_type` in `Nlmsghdr`
-impl_var_trait!(GenlId, u16, NlType,
+impl_var_trait!(
+    /// Values for `nl_type` in `Nlmsghdr`
+    ( GenlId, u16, NlType,
     Ctrl => libc::GENL_ID_CTRL as u16,
     VfsDquot => libc::GENL_ID_VFS_DQUOT as u16,
-    Pmcraid => libc::GENL_ID_PMCRAID as u16
+    Pmcraid => libc::GENL_ID_PMCRAID as u16 )
 );
 
-/// Values for `nl_flags` in `NlHdr`
-impl_var!(NlmF, u16,
+impl_var!(
+    /// Values for `nl_flags` in `NlHdr`
+    ( NlmF, u16,
     Request => libc::NLM_F_REQUEST as u16,
     Multi => libc::NLM_F_MULTI as u16,
     Ack => libc::NLM_F_ACK as u16,
@@ -413,11 +521,12 @@ impl_var!(NlmF, u16,
     Replace => libc::NLM_F_REPLACE as u16,
     Excl => libc::NLM_F_EXCL as u16,
     Create => libc::NLM_F_CREATE as u16,
-    Append => libc::NLM_F_APPEND as u16
+    Append => libc::NLM_F_APPEND as u16 )
 );
 
-/// Values for `cmd` in `GenlHdr`
-impl_var!(CtrlCmd, u8,
+impl_var!(
+    /// Values for `cmd` in `GenlHdr`
+    ( CtrlCmd, u8,
     Unspec => libc::CTRL_CMD_UNSPEC as u8,
     Newfamily => libc::CTRL_CMD_NEWFAMILY as u8,
     Delfamily => libc::CTRL_CMD_DELFAMILY as u8,
@@ -427,11 +536,12 @@ impl_var!(CtrlCmd, u8,
     Getops => libc::CTRL_CMD_GETOPS as u8,
     NewmcastGrp => libc::CTRL_CMD_NEWMCAST_GRP as u8,
     DelmcastGrp => libc::CTRL_CMD_DELMCAST_GRP as u8,
-    GetmcastGrp => libc::CTRL_CMD_GETMCAST_GRP as u8
+    GetmcastGrp => libc::CTRL_CMD_GETMCAST_GRP as u8 )
 );
 
-/// Values for `nla_type` in `NlaAttrHdr`
-impl_var!(CtrlAttr, u16,
+impl_var!(
+    /// Values for `nla_type` in `NlaAttrHdr`
+    ( CtrlAttr, u16,
     Unspec => libc::CTRL_ATTR_UNSPEC as u16,
     FamilyId => libc::CTRL_ATTR_FAMILY_ID as u16,
     FamilyName => libc::CTRL_ATTR_FAMILY_NAME as u16,
@@ -439,12 +549,13 @@ impl_var!(CtrlAttr, u16,
     Hdrsize => libc::CTRL_ATTR_HDRSIZE as u16,
     Maxattr => libc::CTRL_ATTR_MAXATTR as u16,
     Ops => libc::CTRL_ATTR_OPS as u16,
-    McastGroups => libc::CTRL_ATTR_MCAST_GROUPS as u16
+    McastGroups => libc::CTRL_ATTR_MCAST_GROUPS as u16 )
 );
 
-/// Values for `nla_type` in `NlaAttrHdr`
-impl_var!(CtrlAttrMcastGrp, u16,
+impl_var!(
+    /// Values for `nla_type` in `NlaAttrHdr`
+    ( CtrlAttrMcastGrp, u16,
     Unspec => libc::CTRL_ATTR_MCAST_GRP_UNSPEC as u16,
     Name => libc::CTRL_ATTR_MCAST_GRP_NAME as u16,
-    Id => libc::CTRL_ATTR_MCAST_GRP_ID as u16
+    Id => libc::CTRL_ATTR_MCAST_GRP_ID as u16 )
 );


### PR DESCRIPTION
When using this library, I found the system for creating `enum`s that mapped to C constants very helpful when working with new Netlink apis. I had a hard time figuring out how to use it, though, because there wasn't much documentation of the macros, and there was no documentation with the individual constants in `neli::consts::*`. I tried my best to improve the docs so that the constants and macros would be easier to use.

Major Changes:

 * Updated the three constant generating macros with alternate versions that allow
doc comments as the first argument. You can use the macros the same way they were used before, or you can call them with the alternate version so that `cargo docs` shows the constants with the documentation that they are supposed to have.
* Moved the documentation about `impl_var!`, `impl_trait!`, and `impl_var_trait!` to actually live with the macros, instead of at the top of `consts.rs`. This fixes an error `error: missing documentation for macro` when building the library with `cargo 1.33.0-nightly (34320d212 2019-01-03)`. 
* Expanded the documentation for `impl_var!`.

I could use feedback on the new versions of the macros. They should be more convenient to use. Also the individual comments on members of `neli::consts::*` should probably be improved.

It would be good to have a way to specify comments on the individual fields in the constant enums as well.