### PR TITLE
Use get_nested_attributes R type for message type

### DIFF
--- a/src/nlattr.rs
+++ b/src/nlattr.rs
@@ -133,8 +133,8 @@ impl<T> Nlattr<T, Vec<u8>> where T: NlAttrType {
     }
 
     /// Return an `AttrHandle` for attributes nested in the given attribute payload
-    pub fn get_nested_attributes<'a, R>(&'a self) -> Result<AttrHandle<'a, T>, DeError> where R: Nl {
-        Ok(AttrHandle::new(Vec::<Nlattr<T, Vec<u8>>>::deserialize(
+    pub fn get_nested_attributes<'a, R>(&'a self) -> Result<AttrHandle<'a, R>, DeError> where R: NlAttrType {
+        Ok(AttrHandle::new(Vec::<Nlattr<R, Vec<u8>>>::deserialize(
             &mut StreamReadBuffer::new(&self.payload)
         )?))
     }


### PR DESCRIPTION
The template type for `get_nested_attributes` was previously used in neli to specify the Netlink attribute type for the nested attributes. It's currently unused in neli 0.4.2. I think this may have been a typo since forcing all nested types to be T makes parsing nested attributes of a different type than the parent impossible.

If I'm wrong, please feel free to close the pull request.