### PR TITLE
rtnl: Fix Ifinfomsg serialization

### DIFF
--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -179,7 +179,7 @@ mod ifinfomsg_tests {
         assert!(nlmsg.is_ok());
 
         let mut bytes = StreamWriteBuffer::new_growable(None);
-        nlmsg.unwrap().serialize(&mut bytes);
+        nlmsg.unwrap().serialize(&mut bytes).unwrap();
         assert_eq!(bytes.as_ref(), &request[..]);
     }
 }


### PR DESCRIPTION
* Fix serialization and deserialization of `Ifinfomsg`.  There were a few small problems.
* Switch from `AddrFamily` to `Af` enum, as it matches the size of the `ifinfomsg` field (1 byte).
