### PR TITLE
Nlmsgerr can implement debug

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -41,6 +41,7 @@ macro_rules! try_err_compat {
 }
 
 /// Struct representing netlink packets containing errors
+#[derive(Debug)]
 pub struct Nlmsgerr<T> {
     /// Error code
     pub error: libc::c_int,


### PR DESCRIPTION
It comes handy when playing with the protocol.

It would be even better if it could also implement the `Error` and `Display` traits. It seems the error is negative errno, so it could be resolved by using the `std::io::Error`. Is it OK to change the struct to contain that instead of the direct error code? Or maybe add an `Into` implementation?