### PR TITLE
Nflog support MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Additions
+* NFLOG support, in the `netfilter` module.
+
 ## 0.4.3
 ### Breaking changes
 * Change `Nlattr.add_nested_attribute()` to take a reference

--- a/examples/nflog.rs
+++ b/examples/nflog.rs
@@ -1,0 +1,62 @@
+//! This example connects to the netfilter logging facility, group 10 (arbitrarily chosen number),
+//! on INET (IPv4).
+//!
+//! If you want to see it work, log some packets, for example by adding this into the iptables:
+//!
+//! ```sh
+//! iptables -I INPUT -j NFLOG --nflog-group 10 --nflog-prefix "A packet"
+//! ```
+//!
+//! Both this example and the above command needs to be run as root.
+extern crate neli;
+
+use neli::consts::netfilter::{LogCmd, LogCopyMode, NetfilterMsg, NfLogCfg};
+use neli::consts::{NlFamily, NlmF};
+use neli::netfilter::{LogConfigMode, LogConfigReq, LogPacket};
+use neli::nl::Nlmsghdr;
+use neli::nlattr::Nlattr;
+use neli::socket::NlSocket;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // First, let's create a socket to the netfilter.
+    let mut socket = NlSocket::connect(NlFamily::Netfilter, None, None, false)?;
+
+    // Then, ask the kernel to send the relevant packets into it. Unfortunately, the documentation
+    // of the functionality is kind of sparse, so there are some unknowns, like why do we have to
+    // do the PfUnbind first (every other example out there on the Internet does that and doesn't
+    // explain it).
+    let cmds = vec![
+        Nlattr::new(None, NfLogCfg::Cmd, LogCmd::PfUnbind)?,
+        // This one says we are interested in the first 50 bytes of each packet. If not included,
+        // it'll send us the whole packets.
+        Nlattr::new(
+            None,
+            NfLogCfg::Mode,
+            LogConfigMode {
+                copy_mode: LogCopyMode::Packet,
+                copy_range: 50,
+            },
+        )?,
+        Nlattr::new(None, NfLogCfg::Cmd, LogCmd::PfBind)?,
+        Nlattr::new(None, NfLogCfg::Cmd, LogCmd::Bind)?,
+    ];
+    let req = LogConfigReq::new(libc::AF_INET, 10, cmds);
+    let flags = vec![NlmF::Request, NlmF::Ack];
+    let msg = Nlmsghdr::new(None, NetfilterMsg::LogConfig, flags, None, None, req);
+    // Send the request to the kernel
+    socket.send_nl(msg)?;
+    // And check it succeeds.
+    socket.recv_ack()?;
+
+    // Now, let's start getting the packets. A real world application would do something more
+    // useful with them then just print them, but hey, this is an example.
+    for pkt in socket.iter::<NetfilterMsg, LogPacket>() {
+        let pkt = pkt?;
+        match pkt.nl_type {
+            NetfilterMsg::LogPacket => println!("{:?}", pkt.nl_payload),
+            // TODO: Does anyone have any idea what these messages are and why we get them?
+            _ => println!("Some other message received"),
+        }
+    }
+    Ok(())
+}

--- a/src/consts/mod.rs
+++ b/src/consts/mod.rs
@@ -37,6 +37,7 @@ mod macros;
 /// Constants related to generic netlink
 pub mod genl;
 pub use crate::consts::genl::*;
+pub mod netfilter;
 /// Constants related to generic netlink attributes
 pub mod nlattr;
 pub use crate::consts::nlattr::*;

--- a/src/consts/netfilter.rs
+++ b/src/consts/netfilter.rs
@@ -1,0 +1,78 @@
+//! Constants for netfilter related protocols
+//!
+//! Note that this doesn't cover everything yet, both the list of types and variants in enums will
+//! be added over time.
+
+use super::{NlAttrType, NlType};
+
+impl_var_trait! {
+    /// Attributes inside a netfilter log packet message.
+    ///
+    /// These are send by the kernel and describe a logged packet.
+    NfLogAttr, u16, NlAttrType,
+    PacketHdr => 1,
+    Mark => 2,
+    Timestamp => 3,
+    IfindexIndev => 4,
+    IfindexOutdev => 5,
+    IfindexPhyindev => 6,
+    IfindexPhyoutdev => 7,
+    Hwaddr => 8,
+    Payload => 9,
+    Prefix => 10,
+    Uid => 11,
+    Seq => 12,
+    SeqGlobal => 13,
+    Gid => 14,
+    Hwtype => 15,
+    Hwheader => 16,
+    Hwlen => 17,
+    Ct => 18,
+    CtInfo => 19
+}
+
+impl_var_trait! {
+    /// Configuration attributes for netfilter logging.
+    ///
+    /// See [LogConfigReq][crate::netfilter::LogConfigReq]
+    NfLogCfg, u16, NlAttrType,
+    Cmd => 1,
+    Mode => 2,
+    NlBufSize => 3,
+    Timeout => 4,
+    QThresh => 5,
+    Flags => 6
+}
+
+impl_var_trait! {
+    /// Messages related to the netfilter netlink protocols.
+    ///
+    /// These appear on the [NlFamily::Netfilter][super::NlFamily::Netfilter] sockets.
+    NetfilterMsg, u16, NlType,
+    // TODO: Docs here /// A logged packet, going from kernel to userspace.
+    LogPacket => 0x0400,
+    // TODO: Docs here /// A logging configuration request, going from userspace to kernel.
+    LogConfig => 0x0401
+}
+
+impl_trait! {
+    /// Parameters for the [NfLogCfg::Cmd].
+    LogCfgCmd, u8
+}
+
+impl_var_trait! {
+    /// Command value for the [NfLogCfg::Cmd].
+    LogCmd, u8, LogCfgCmd,
+    Bind => 1,
+    Unbind => 2,
+    PfBind => 3,
+    PfUnbind => 4
+}
+
+impl_var! {
+    /// Copy mode of the logged packets.
+    LogCopyMode, u8,
+    None => 0,
+    Meta => 1,
+    Packet => 2
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //! code.
 //! * `genl` - This code provides parsing for the generic netlink subsystem of the netlink
 //! protocol.
+//! * `netfilter` - Netfilter related protocols (NFLOG, NFQUEUE, CONNTRACK).
 //! * `nlattr` - This code provides more granular parsing methods for the generic netlink
 //! attributes in the context of generic netlink requests and responses.
 //! * `nl` - This is the top level netlink header code that handles the header that all netlink
@@ -68,6 +69,7 @@ pub mod consts;
 pub mod err;
 /// Genetlink (generic netlink) header and attribute helpers
 pub mod genl;
+pub mod netfilter;
 /// Top-level netlink header
 pub mod nl;
 /// Netlink attribute handler

--- a/src/netfilter.rs
+++ b/src/netfilter.rs
@@ -1,0 +1,285 @@
+//! Netfilter protocols
+//!
+//! Protocols used for communicating with netfilter. Currently, this contains (partial) support for
+//! NFLOG, NFQUEUE and CONNTRACK will be added later.
+//!
+//! See the examples in the git repository for actual, working code.
+
+use std::ffi::CString;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use libc::c_int;
+
+use crate::consts::netfilter::{LogCopyMode, NfLogAttr, NfLogCfg};
+use crate::err::{DeError, SerError};
+use crate::nlattr::Nlattr;
+use crate::{Nl, StreamReadBuffer, StreamWriteBuffer};
+
+type Nlattrs = Vec<Nlattr<NfLogAttr, Vec<u8>>>;
+
+#[derive(Copy, Clone, Debug)]
+struct Timestamp {
+    secs: u64,
+    usecs: u64,
+}
+
+impl Nl for Timestamp {
+    fn serialize(&self, m: &mut StreamWriteBuffer) -> Result<(), SerError> {
+        u64::to_be(self.secs).serialize(m)?;
+        u64::to_be(self.usecs).serialize(m)?;
+        Ok(())
+    }
+    fn deserialize<B: AsRef<[u8]>>(m: &mut StreamReadBuffer<B>) -> Result<Self, DeError> {
+        let secs = u64::from_be(u64::deserialize(m)?);
+        let usecs = u64::from_be(u64::deserialize(m)?);
+        Ok(Self { secs, usecs })
+    }
+    fn size(&self) -> usize {
+        self.secs.size() + self.usecs.size()
+    }
+}
+
+impl Into<SystemTime> for Timestamp {
+    fn into(self) -> SystemTime {
+        let dur = Duration::new(self.secs, (self.usecs * 1000) as u32);
+        UNIX_EPOCH + dur
+    }
+}
+
+/// A logged packet sent from the kernel to userspace.
+///
+/// Note that further fields will be added over time.
+#[derive(Clone, Debug)]
+pub struct LogPacket {
+    /// No idea what this is :-(
+    pub hw_protocol: u16,
+    /// No idea what this is :-(
+    pub hook: u8,
+    /// A packet mark.
+    ///
+    /// A mark used through the netfilter, working as kind of scratch memory. 0 and no mark set are
+    /// considered equivalent.
+    pub mark: u16,
+    /// A timestamp when the packet has been captured.
+    pub timestamp: SystemTime,
+    /// Source hardware address (eg. MAC).
+    ///
+    /// This might be missing in case it is not yet known at the point of packet capture (outgoing
+    /// packets before routing decisions) or on interfaces that don't have hardware addresses
+    /// (`lo`).
+    pub hwaddr: Vec<u8>,
+    /// Payload of the packet.
+    pub payload: Vec<u8>,
+    /// Prefix, set at the capturing rule. May be empty.
+    pub prefix: CString,
+    /// Index of the inbound interface, if any.
+    pub ifindex_in: Option<u32>,
+    /// Index of the outbound interface, if any.
+    pub ifindex_out: Option<u32>,
+    /// Index of the physical inbound interface, if any.
+    pub ifindex_physin: Option<u32>,
+    /// Index of the physical outbound interface, if any.
+    pub ifindex_physout: Option<u32>,
+    /// UID of the socket this packet belongs to.
+    pub uid: Option<u32>,
+    /// GID of the socket this packet belongs to.
+    pub gid: Option<u32>,
+    // TODO: More
+    // * Seq is probably not useful
+    // * What is the HWTYPE/stuff?
+    // * Conntrack
+
+    // Internal use, remembering the size this was encoded as.
+    // It also prevents user from creating this directly, therefore forward-proofs it as adding
+    // more fields won't be a breaking change.
+    attr_len: usize,
+}
+
+impl LogPacket {
+    /// Creates a dummy instance.
+    ///
+    /// This can be used in eg. tests, or to create an instance and set certain fields. This is
+    /// similar to the [Default] trait, except unlike default instances, this one doesn't actually
+    /// make much sense.
+    pub fn dummy_instance() -> Self {
+        Self {
+            hw_protocol: 0,
+            hook: 0,
+            mark: 0,
+            timestamp: UNIX_EPOCH,
+            hwaddr: Vec::new(),
+            payload: Vec::new(),
+            prefix: CString::default(),
+            ifindex_in: None,
+            ifindex_out: None,
+            ifindex_physin: None,
+            ifindex_physout: None,
+            uid: None,
+            gid: None,
+            attr_len: 0,
+        }
+    }
+}
+
+impl Nl for LogPacket {
+    fn serialize(&self, _: &mut StreamWriteBuffer) -> Result<(), SerError> {
+        unimplemented!("The NFLOG protocol never sends packets to kernel, no reason to know how to serialize them");
+    }
+    fn deserialize<B: AsRef<[u8]>>(m: &mut StreamReadBuffer<B>) -> Result<Self, DeError> {
+        let hint = m.take_size_hint().map(|h| h.saturating_sub(4));
+        let hw_protocol = u16::from_be(Nl::deserialize(m)?);
+        let hook = Nl::deserialize(m)?;
+        let _pad: u8 = Nl::deserialize(m)?;
+        m.set_size_hint(hint.unwrap_or_default());
+        let attrs = Nlattrs::deserialize(m)?;
+        let attr_len = attrs.asize();
+        let mut result = Self::dummy_instance();
+        result.hw_protocol = hw_protocol;
+        result.hook = hook;
+        result.attr_len = attr_len;
+
+        for attr in attrs {
+            match attr.nla_type {
+                NfLogAttr::Mark => result.mark = attr.get_payload_as()?,
+                NfLogAttr::Timestamp => {
+                    result.timestamp = attr.get_payload_as::<Timestamp>()?.into();
+                }
+                NfLogAttr::Hwaddr => {
+                    let mut buffer = StreamReadBuffer::new(&attr.payload);
+                    let len = u16::from_be(u16::deserialize(&mut buffer)?);
+                    let mut hwaddr = attr.payload;
+                    // Drop the len and padding
+                    hwaddr.drain(..4);
+                    hwaddr.truncate(len as usize);
+                    hwaddr.shrink_to_fit();
+                    result.hwaddr = hwaddr;
+                }
+                NfLogAttr::Payload => result.payload = attr.payload,
+                NfLogAttr::Prefix => {
+                    let mut bytes = attr.payload;
+                    // get rid of null byte, CString::new adds it and wants it not to have it there.
+                    // Usually, there's only one null byte, but who knows what comes from the
+                    // kernel, therefore we just make sure to do *something* in case there are
+                    // nulls in the middle too.
+                    bytes.retain(|b| *b != 0);
+                    result.prefix = CString::new(bytes).expect("Leftover null byte");
+                }
+                NfLogAttr::IfindexIndev => {
+                    result.ifindex_in = Some(u32::from_be(attr.get_payload_as()?))
+                }
+                NfLogAttr::IfindexOutdev => {
+                    result.ifindex_out = Some(u32::from_be(attr.get_payload_as()?))
+                }
+                NfLogAttr::IfindexPhyindev => {
+                    result.ifindex_physin = Some(u32::from_be(attr.get_payload_as()?))
+                }
+                NfLogAttr::IfindexPhyoutdev => {
+                    result.ifindex_physout = Some(u32::from_be(attr.get_payload_as()?))
+                }
+                NfLogAttr::Uid => result.uid = Some(u32::from_be(attr.get_payload_as()?)),
+                NfLogAttr::Gid => result.gid = Some(u32::from_be(attr.get_payload_as()?)),
+                _ => (),
+            }
+        }
+        Ok(result)
+    }
+    fn size(&self) -> usize {
+        4 + self.attr_len
+    }
+}
+
+/// A configuration request, to bind a socket to specific logging group.
+#[derive(Debug)]
+pub struct LogConfigReq {
+    family: u8,
+    group: u16,
+    attrs: Vec<Nlattr<NfLogCfg, Vec<u8>>>,
+}
+
+impl LogConfigReq {
+    /// Creates a new log configuration request.
+    ///
+    /// It should be sent to the kernel in a
+    /// [NetfilterMsg::LogConfig][crate::consts::netfilter::NetfilterMsg::LogConfig] message.
+    ///
+    /// ```rust
+    /// # use neli::consts::netfilter::{NfLogCfg, LogCmd, LogCopyMode};
+    /// # use neli::nlattr::Nlattr;
+    /// # use neli::netfilter::{LogConfigMode, LogConfigReq};
+    /// // A request to attach the socket to log group 10 on the AF_INET protocol.
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let cfg = vec![
+    ///     Nlattr::new(None, NfLogCfg::Cmd, LogCmd::PfUnbind)?,
+    ///     Nlattr::new(None, NfLogCfg::Mode, LogConfigMode {
+    ///         copy_mode: LogCopyMode::Packet,
+    ///         copy_range: 50,
+    ///     })?,
+    ///     Nlattr::new(None, NfLogCfg::Cmd, LogCmd::PfBind)?,
+    ///     Nlattr::new(None, NfLogCfg::Cmd, LogCmd::Bind)?,
+    /// ];
+    /// let req = LogConfigReq::new(libc::AF_INET, 10, cfg);
+    /// # Ok(()) }
+    /// ```
+    pub fn new(family: c_int, group: u16, cfg: Vec<Nlattr<NfLogCfg, Vec<u8>>>) -> Self {
+        assert!(family >= 0);
+        assert!(family <= 255);
+        Self {
+            family: family as u8,
+            group,
+            attrs: cfg,
+        }
+    }
+}
+
+impl Nl for LogConfigReq {
+    fn serialize(&self, m: &mut StreamWriteBuffer) -> Result<(), SerError> {
+        self.family.serialize(m)?;
+        // protocol version
+        0u8.serialize(m)?;
+        u16::to_be(self.group).serialize(m)?;
+        self.attrs.serialize(m)?;
+        self.pad(m)?;
+        Ok(())
+    }
+    fn deserialize<B: AsRef<[u8]>>(_m: &mut StreamReadBuffer<B>) -> Result<Self, DeError> {
+        unimplemented!("Config requests are never sent by the kernel")
+    }
+    fn size(&self) -> usize {
+        self.family.size() + 0u8.size() + self.group.size() + self.attrs.asize()
+    }
+}
+
+/// Configuration mode, as a parameter to [NfLogCfg::Mode].
+#[derive(Clone, Debug)]
+pub struct LogConfigMode {
+    /// Range of bytes to copy.
+    ///
+    /// TODO: All lengths in netlink are u16, why is this u32? Does it mean one should specify both
+    /// ends of the range somehow? How?
+    pub copy_range: u32,
+    /// What parts should be sent.
+    pub copy_mode: LogCopyMode,
+}
+
+impl Nl for LogConfigMode {
+    fn serialize(&self, m: &mut StreamWriteBuffer) -> Result<(), SerError> {
+        u32::to_be(self.copy_range).serialize(m)?;
+        self.copy_mode.serialize(m)?;
+        // A padding
+        0u8.serialize(m)?;
+        Ok(())
+    }
+    fn deserialize<B: AsRef<[u8]>>(m: &mut StreamReadBuffer<B>) -> Result<Self, DeError> {
+        let copy_range = u32::from_be(u32::deserialize(m)?);
+        let copy_mode = LogCopyMode::deserialize(m)?;
+        // A padding
+        u8::deserialize(m)?;
+        Ok(Self {
+            copy_range,
+            copy_mode,
+        })
+    }
+    fn size(&self) -> usize {
+        self.copy_range.size() + self.copy_mode.size() + 0u8.size()
+    }
+}


### PR DESCRIPTION
Hello

This adds the support for basic use of the nflog protocol. There are still some parts missing, but I'd prefer to have a feedback about it sooner than later and I tried to make sure all the missing pieces can be added without breaking API.

I've also tried to structure it in a way that makes it possible/natural to add all the other netfilter protocols over time (NFQUEUE, CONNTRACK).

There are, however, few things I'm not entirely happy about or don't know how to handle properly. I'll probably open separate issues to discuss them one by one, if there's some nice solution for them. But I'll still list my worries here first.

* When receiving messages over the socket, I have to specify into what type I want them to deserialize. But this might depend on the type. This can be seen on the added example, sometimes I get a message with type 3 ‒ which I think corresponds to NLMSG_DONE. I'm not sure if I should make it part of the new `NetfilterMsg` enum, but that would still not help much, because it would still try to deserialize the rest as `LogPacket`. This doesn't currently fail, but is kind of wrong. It would be great if I could somehow specify a nl-type => parse type relation. Unlike `NlAttr<_, Vec<u8>>`, the Nlmsghdr<_, Vec<u8>>` doesn't have methods to parse as one or another type.
* Some of the structs/messages are ever sent in only one direction. So it makes no sense to provide eg. `serialize` for the `LogPacket`. For now, I've put `unimplemented` in them, but it kind of doesn't feel right. Would it make sense to split the Nl trait into reading and writing halves?
* The crate uses the `Vec` type quite generously. For example, when parsing a message, it allocates a Vec as the receive buffer, then it allocates a Vec for all the attributes and, as they have diffferent types, each one is a smaller Vec... As the Vec contains a heap allocation, it might turn somewhat expensive. This probably doesn't matter for things like manipulating the routing table, but with the NFLOG, the number of packets received per second can be quite huge. It would be great if there was a way to use the library with smaller number of allocations (some of my ideas could get down to 0 per packet).
* The `impl_*` macros don't want to let me put documentation onto the individual variants. I've tried to poke at them a little bit, but I've managed to only break existing code, so I've given up for now.

Anyway, if I'm missing anything important here, or if there's any way to improve the code or interface, I'm happy to hear it. I'd then add some fixup commits and rebuild the branch before merging.