### PR TITLE
Simplify structs by removing type variables in rtnl

### DIFF
--- a/examples/route-list.rs
+++ b/examples/route-list.rs
@@ -9,7 +9,7 @@ use neli::nl::Nlmsghdr;
 use neli::rtnl::*;
 use neli::socket::*;
 
-fn parse_route_table(rtm: Nlmsghdr<Rtm, Rtmsg<Rta>>) {
+fn parse_route_table(rtm: Nlmsghdr<Rtm, Rtmsg>) {
     // This sample is only interested in the main table.
     if rtm.nl_payload.rtm_table == RtTable::Main {
         let mut src = None;
@@ -63,7 +63,7 @@ fn parse_route_table(rtm: Nlmsghdr<Rtm, Rtmsg<Rta>>) {
 fn main() -> Result<(), Box<dyn Error>> {
     let mut socket = NlSocket::connect(NlFamily::Route, None, None, true).unwrap();
 
-    let rtmsg: Rtmsg<Rta> = Rtmsg {
+    let rtmsg = Rtmsg {
         rtm_family: RtAddrFamily::Inet,
         rtm_dst_len: 0,
         rtm_src_len: 0,
@@ -87,11 +87,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     socket.send_nl(nlhdr).unwrap();
 
     // Provisionally deserialize as a Nlmsg first.
-    let nl = socket.recv_nl::<Rtm, Rtmsg<Rta>>(None)?;
+    let nl = socket.recv_nl::<Rtm, Rtmsg>(None)?;
     let multi_msg = nl.nl_flags.contains(&NlmF::Multi);
     parse_route_table(nl);
     if multi_msg {
-        while let Ok(nl) = socket.recv_nl::<u16, Rtmsg<Rta>>(None) {
+        while let Ok(nl) = socket.recv_nl::<u16, Rtmsg>(None) {
             match Nlmsg::from(nl.nl_type) {
                 Nlmsg::Done => return Ok(()),
                 Nlmsg::Error => return Err(Box::new(NlError::new("rtnetlink error."))),

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -121,7 +121,7 @@ where
 
 /// Struct representing interface information messages
 #[derive(Debug)]
-pub struct Ifinfomsg<T> {
+pub struct Ifinfomsg {
     /// Interface address family
     pub ifi_family: RtAddrFamily,
     /// Interface type
@@ -132,20 +132,17 @@ pub struct Ifinfomsg<T> {
     pub ifi_flags: Vec<Iff>,
     ifi_change: libc::c_uint,
     /// Payload of `Rtattr`s
-    pub rtattrs: Rtattrs<T, Vec<u8>>,
+    pub rtattrs: Rtattrs<Ifla, Vec<u8>>,
 }
 
-impl<T> Ifinfomsg<T>
-where
-    T: RtaType,
-{
+impl Ifinfomsg {
     /// Create a fully initialized interface info struct
     pub fn new(
         ifi_family: RtAddrFamily,
         ifi_type: Arphrd,
         ifi_index: libc::c_int,
         ifi_flags: Vec<Iff>,
-        rtattrs: Rtattrs<T, Vec<u8>>,
+        rtattrs: Rtattrs<Ifla, Vec<u8>>,
     ) -> Self {
         Ifinfomsg {
             ifi_family,
@@ -158,10 +155,7 @@ where
     }
 }
 
-impl<T> Nl for Ifinfomsg<T>
-where
-    T: RtaType,
-{
+impl Nl for Ifinfomsg {
     fn serialize(&self, buf: &mut StreamWriteBuffer) -> Result<(), SerError> {
         self.ifi_family.serialize(buf)?;
         0u8.serialize(buf)?; // padding
@@ -214,7 +208,7 @@ where
             )
             .ok_or_else(|| DeError::new(&format!("Truncated Ifinfomsg size_hint {}", size_hint)))?;
         buf.set_size_hint(size_hint);
-        let rtattrs = Rtattrs::<T, Vec<u8>>::deserialize(buf)?;
+        let rtattrs = Rtattrs::<Ifla, Vec<u8>>::deserialize(buf)?;
 
         Ok(Ifinfomsg {
             ifi_family,
@@ -240,7 +234,7 @@ where
 
 /// Struct representing interface address messages
 #[derive(Debug)]
-pub struct Ifaddrmsg<T> {
+pub struct Ifaddrmsg {
     /// Interface address family
     pub ifa_family: RtAddrFamily,
     /// Interface address prefix length
@@ -252,13 +246,10 @@ pub struct Ifaddrmsg<T> {
     /// Interface address index
     pub ifa_index: libc::c_int,
     /// Payload of `Rtattr`s
-    pub rtattrs: Rtattrs<T, Vec<u8>>,
+    pub rtattrs: Rtattrs<Ifa, Vec<u8>>,
 }
 
-impl<T> Nl for Ifaddrmsg<T>
-where
-    T: RtaType,
-{
+impl Nl for Ifaddrmsg {
     fn serialize(&self, buf: &mut StreamWriteBuffer) -> Result<(), SerError> {
         self.ifa_family.serialize(buf)?;
         self.ifa_prefixlen.serialize(buf)?;
@@ -345,7 +336,7 @@ impl Nl for Rtgenmsg {
 
 /// Route message
 #[derive(Debug)]
-pub struct Rtmsg<T> {
+pub struct Rtmsg {
     /// Address family of route
     pub rtm_family: RtAddrFamily,
     /// Length of destination
@@ -365,13 +356,10 @@ pub struct Rtmsg<T> {
     /// Routing flags
     pub rtm_flags: Vec<RtmF>,
     /// Payload of `Rtattr`s
-    pub rtattrs: Rtattrs<T, Vec<u8>>,
+    pub rtattrs: Rtattrs<Rta, Vec<u8>>,
 }
 
-impl<T> Nl for Rtmsg<T>
-where
-    T: RtaType,
-{
+impl Nl for Rtmsg {
     fn serialize(&self, buf: &mut StreamWriteBuffer) -> Result<(), SerError> {
         self.rtm_family.serialize(buf)?;
         self.rtm_dst_len.serialize(buf)?;
@@ -432,7 +420,7 @@ where
                 - rtm_type.size()
                 - mem::size_of::<libc::c_int>(),
         );
-        let rtattrs = Rtattrs::<T, Vec<u8>>::deserialize(buf)?;
+        let rtattrs = Rtattrs::<Rta, Vec<u8>>::deserialize(buf)?;
 
         Ok(Rtmsg {
             rtm_family,
@@ -585,7 +573,7 @@ impl Nl for NdaCacheinfo {
 
 /// Message in response to queuing discipline operations
 #[derive(Debug)]
-pub struct Tcmsg<T> {
+pub struct Tcmsg {
     /// Family
     pub tcm_family: libc::c_uchar,
     /// Interface index
@@ -597,13 +585,10 @@ pub struct Tcmsg<T> {
     /// Info
     pub tcm_info: u32,
     /// Payload of `Rtattr`s
-    pub rtattrs: Rtattrs<T, Vec<u8>>,
+    pub rtattrs: Rtattrs<Tca, Vec<u8>>,
 }
 
-impl<T> Nl for Tcmsg<T>
-where
-    T: RtaType,
-{
+impl Nl for Tcmsg {
     fn serialize(&self, buf: &mut StreamWriteBuffer) -> Result<(), SerError> {
         self.tcm_family.serialize(buf)?;
         self.tcm_ifindex.serialize(buf)?;
@@ -624,7 +609,7 @@ where
             tcm_handle: u32::deserialize(buf)?,
             tcm_parent: u32::deserialize(buf)?,
             tcm_info: u32::deserialize(buf)?,
-            rtattrs: Rtattrs::<T, Vec<u8>>::deserialize(buf)?,
+            rtattrs: Rtattrs::<Tca, Vec<u8>>::deserialize(buf)?,
         })
     }
 


### PR DESCRIPTION
Rtattrs have specific type depending on the struct. Remove type variable to simplify using these structs and remove possibility to make mistakes.

I made the mistake of using wrong type and spend embarrassingly amount of time figuring out what happens. I opened this PR which implements simpler structs for `rtnl` so that I can give it a more test.

Related to #54.