### PR TITLE
Fix `Ndmsg` struct

### DIFF
--- a/src/consts/rtnl.rs
+++ b/src/consts/rtnl.rs
@@ -230,6 +230,24 @@ impl_var_trait!(
     Stab => libc::TCA_STAB
 );
 
+impl_var_trait!(
+    /// Enum for use with `Rtattr.rta_type` -
+    /// Values specify neighbor table attributes
+    Nda, libc::c_ushort, RtaType,
+    Unspec => libc::NDA_UNSPEC,
+    Dst => libc::NDA_DST,
+    Lladdr => libc::NDA_LLADDR,
+    Cacheinfo => libc::NDA_CACHEINFO,
+    Probes => libc::NDA_PROBES,
+    Vlan => libc::NDA_VLAN,
+    Port => libc::NDA_PORT,
+    Vni => libc::NDA_VNI,
+    Ifindex => libc::NDA_IFINDEX,
+    Master => libc::NDA_MASTER,
+    LinkNetnsid => libc::NDA_LINK_NETNSID,
+    SrcVni => libc::NDA_SRC_VNI
+);
+
 impl_var!(
     /// Interface types
     Arphrd, libc::c_ushort,

--- a/src/consts/rtnl.rs
+++ b/src/consts/rtnl.rs
@@ -243,8 +243,11 @@ impl_var_trait!(
     Port => libc::NDA_PORT,
     Vni => libc::NDA_VNI,
     Ifindex => libc::NDA_IFINDEX,
+    #[cfg(target_env="gnu")]
     Master => libc::NDA_MASTER,
+    #[cfg(target_env="gnu")]
     LinkNetnsid => libc::NDA_LINK_NETNSID,
+    #[cfg(target_env="gnu")]
     SrcVni => libc::NDA_SRC_VNI
 );
 

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -462,7 +462,7 @@ pub struct Ndmsg {
     /// Flags for entry
     pub ndm_flags: Vec<Ntf>,
     /// Type of entry
-    pub ndm_type: u8,
+    pub ndm_type: Rtn,
     /// Payload of `Rtattr`s
     pub rtattrs: Rtattrs<Nda, Vec<u8>>,
 }
@@ -526,7 +526,7 @@ impl Nl for Ndmsg {
             }
             ndm_flags
         };
-        let ndm_type = u8::deserialize(buf)?;
+        let ndm_type = Rtn::deserialize(buf)?;
 
         buf.set_size_hint(
             size_hint

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -535,7 +535,7 @@ impl Nl for Ndmsg {
                 - ndm_index.size()
                 - mem::size_of::<u16>() // ndm_state
                 - mem::size_of::<u8>() // ndm_flags
-                - ndm_type.size()
+                - ndm_type.size(),
         );
 
         let rtattrs = Rtattrs::<Nda, Vec<u8>>::deserialize(buf)?;

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -462,12 +462,16 @@ pub struct Ndmsg {
     /// Flags for entry
     pub ndm_flags: Vec<Ntf>,
     /// Type of entry
-    pub ndm_type: Rtn,
+    pub ndm_type: u8,
+    /// Payload of `Rtattr`s
+    pub rtattrs: Rtattrs<Nda, Vec<u8>>,
 }
 
 impl Nl for Ndmsg {
     fn serialize(&self, buf: &mut StreamWriteBuffer) -> Result<(), SerError> {
         self.ndm_family.serialize(buf)?;
+        0u8.serialize(buf)?; // padding
+        0u16.serialize(buf)?; // padding
         self.ndm_index.serialize(buf)?;
         self.ndm_state
             .iter()
@@ -484,6 +488,7 @@ impl Nl for Ndmsg {
             })
             .serialize(buf)?;
         self.ndm_type.serialize(buf)?;
+        self.rtattrs.serialize(buf)?;
         Ok(())
     }
 
@@ -491,41 +496,68 @@ impl Nl for Ndmsg {
     where
         B: AsRef<[u8]>,
     {
+        let size_hint = buf
+            .take_size_hint()
+            .ok_or_else(|| DeError::new("Must provide size hint to deserialize Ndmsg"))?;
+
+        let ndm_family = RtAddrFamily::deserialize(buf)?;
+        u8::deserialize(buf)?; // padding
+        u16::deserialize(buf)?; // padding
+        let ndm_index = libc::c_int::deserialize(buf)?;
+        let ndm_state = {
+            let state = u16::deserialize(buf)?;
+            let mut ndm_state = Vec::new();
+            for i in 0..mem::size_of::<u16>() * 8 {
+                let bit = 1 << i;
+                if bit & state == bit {
+                    ndm_state.push((bit as u16).into());
+                }
+            }
+            ndm_state
+        };
+        let ndm_flags = {
+            let flags = u8::deserialize(buf)?;
+            let mut ndm_flags = Vec::new();
+            for i in 0..mem::size_of::<u8>() * 8 {
+                let bit = 1 << i;
+                if bit & flags == bit {
+                    ndm_flags.push((bit as u8).into());
+                }
+            }
+            ndm_flags
+        };
+        let ndm_type = u8::deserialize(buf)?;
+
+        buf.set_size_hint(
+            size_hint
+                - ndm_family.size()
+                - 3 // padding of u8 + u16
+                - ndm_index.size()
+                - mem::size_of::<u16>() // ndm_state
+                - mem::size_of::<u8>() // ndm_flags
+                - ndm_type.size()
+        );
+
+        let rtattrs = Rtattrs::<Nda, Vec<u8>>::deserialize(buf)?;
+
         Ok(Ndmsg {
-            ndm_family: RtAddrFamily::deserialize(buf)?,
-            ndm_index: libc::c_int::deserialize(buf)?,
-            ndm_state: {
-                let state = u16::deserialize(buf)?;
-                let mut ndm_state = Vec::new();
-                for i in 0..mem::size_of::<u16>() * 8 {
-                    let bit = 1 << i;
-                    if bit & state == bit {
-                        ndm_state.push((bit as u16).into());
-                    }
-                }
-                ndm_state
-            },
-            ndm_flags: {
-                let flags = u8::deserialize(buf)?;
-                let mut ndm_flags = Vec::new();
-                for i in 0..mem::size_of::<u8>() * 8 {
-                    let bit = 1 << i;
-                    if bit & flags == bit {
-                        ndm_flags.push((bit as u8).into());
-                    }
-                }
-                ndm_flags
-            },
-            ndm_type: Rtn::deserialize(buf)?,
+            ndm_family,
+            ndm_index,
+            ndm_state,
+            ndm_flags,
+            ndm_type,
+            rtattrs,
         })
     }
 
     fn size(&self) -> usize {
         self.ndm_family.size()
+            + 3 // padding of u8 + u16
             + self.ndm_index.size()
-            + mem::size_of::<u16>()
-            + mem::size_of::<u8>()
+            + mem::size_of::<u16>() // ndm_state
+            + mem::size_of::<u8>() // ndm_flags
             + self.ndm_type.size()
+            + self.rtattrs.asize()
     }
 }
 


### PR DESCRIPTION
As documented in #56, `Ndmsg` struct is broken. This PR fixes it by adding the missing `rtattr` field for the struct, add the missing `rta_type` for `Rtattr`s as well as fixing the alignment of the struct with correct padding. Finally of course fixing the length calculations.

I couldn't find any docs (or use case) for `Ndmsg.ndm_type`, so I changed it to `u8`. It's there, but no idea what it should be used for.

Fixes #56