### PR TITLE
Extend RtAddrFamily and allow changing change mask

### DIFF
--- a/src/consts/rtnl.rs
+++ b/src/consts/rtnl.rs
@@ -8,6 +8,7 @@ impl_var!(
 impl_var!(
     /// General address families for sockets
     RtAddrFamily, u8,
+    Unspecified => libc::AF_UNSPEC as u8,
     UnixOrLocal => libc::AF_UNIX as u8,
     Inet => libc::AF_INET as u8,
     Inet6 => libc::AF_INET6 as u8,

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -167,7 +167,7 @@ impl Ifinfomsg {
             ifi_type,
             ifi_index,
             ifi_flags: vec![Iff::Up],
-            ifi_change: Iff::Up.into(),
+            ifi_change: Iff::Up,
             rtattrs,
         }
     }
@@ -184,7 +184,7 @@ impl Ifinfomsg {
             ifi_type,
             ifi_index,
             ifi_flags: Vec::new(),
-            ifi_change: Iff::Up.into(),
+            ifi_change: Iff::Up,
             rtattrs,
         }
     }

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -130,7 +130,8 @@ pub struct Ifinfomsg {
     pub ifi_index: libc::c_int,
     /// Interface flags
     pub ifi_flags: Vec<Iff>,
-    ifi_change: libc::c_uint,
+    /// Change mask
+    pub ifi_change: libc::c_uint,
     /// Payload of `Rtattr`s
     pub rtattrs: Rtattrs<Ifla, Vec<u8>>,
 }
@@ -152,6 +153,11 @@ impl Ifinfomsg {
             ifi_change: 0xffff_ffff,
             rtattrs,
         }
+    }
+
+    /// Set change mask
+    pub fn set_ifi_change(&mut self, ifi_change: libc::c_uint) {
+        self.ifi_change = ifi_change;
     }
 }
 

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -155,9 +155,38 @@ impl Ifinfomsg {
         }
     }
 
-    /// Set change mask
-    pub fn set_ifi_change(&mut self, ifi_change: libc::c_uint) {
-        self.ifi_change = ifi_change;
+    /// Set the link with the given index up (equivalent to `ip link set dev DEV up`)
+    pub fn up(
+        ifi_family: RtAddrFamily,
+        ifi_type: Arphrd,
+        ifi_index: libc::c_int,
+        rtattrs: Rtattrs<Ifla, Vec<u8>>,
+    ) -> Self {
+        Ifinfomsg {
+            ifi_family,
+            ifi_type,
+            ifi_index,
+            ifi_flags: vec![Iff::Up],
+            ifi_change: Iff::Up.into(),
+            rtattrs,
+        }
+    }
+
+    /// Set the link with the given index down (equivalent to `ip link set dev DEV down`)
+    pub fn down(
+        ifi_family: RtAddrFamily,
+        ifi_type: Arphrd,
+        ifi_index: libc::c_int,
+        rtattrs: Rtattrs<Ifla, Vec<u8>>,
+    ) -> Self {
+        Ifinfomsg {
+            ifi_family,
+            ifi_type,
+            ifi_index,
+            ifi_flags: Vec::new(),
+            ifi_change: Iff::Up.into(),
+            rtattrs,
+        }
     }
 }
 

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -131,7 +131,7 @@ pub struct Ifinfomsg {
     /// Interface flags
     pub ifi_flags: Vec<Iff>,
     /// Change mask
-    pub ifi_change: libc::c_uint,
+    pub ifi_change: Iff,
     /// Payload of `Rtattr`s
     pub rtattrs: Rtattrs<Ifla, Vec<u8>>,
 }
@@ -150,7 +150,7 @@ impl Ifinfomsg {
             ifi_type,
             ifi_index,
             ifi_flags,
-            ifi_change: 0xffff_ffff,
+            ifi_change: Iff::from(0xffff_ffff),
             rtattrs,
         }
     }
@@ -230,7 +230,7 @@ impl Nl for Ifinfomsg {
             }
             nl_flags
         };
-        let ifi_change = libc::c_uint::deserialize(buf)?;
+        let ifi_change: Iff = libc::c_uint::deserialize(buf)?.into();
 
         size_hint = size_hint
             .checked_sub(


### PR DESCRIPTION
I'm working on [exchanging](https://github.com/mbr/socketcan-rs/pull/13) the netlink-rs dependency in the socketcan-rs crate for neli but need this two changes to make it work. 
Adding `set_ifi_change` instead of specifying it in the new fn should make this a nonbreaking change.
 