### PR TITLE
Handle missing padding after last attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,9 @@ pub trait Nl: Sized {
     {
         let padding_len = self.asize() - self.size();
         if padding_len > 0 {
-            m.read_exact(&mut [0; libc::NLA_ALIGNTO as usize][..padding_len])?;
+            // Ignore result - the padding is mandatory between attributes, but not after the last
+            // one, so we can get a short read at the very end.
+            let _ = m.read_exact(&mut [0; libc::NLA_ALIGNTO as usize][..padding_len]);
         }
         Ok(())
     }


### PR DESCRIPTION
The requirement is for each attribute to *start* on word boundary, but
not necessarily end, it seems to be legal for the last attribute in a
message (and buffer) not to be followed by a padding. Apparently at
least the NFQUEUE takes advantage and sends such messages.

This relaxes the strictness about that and silently just assumes the end
of buffer was reached.

I'm not 100% sure all three changes are needed, I was discovering them one by one by the means of hunting errors and panics.