### PR TITLE
Fix the nflog mark

### DIFF
--- a/src/netfilter.rs
+++ b/src/netfilter.rs
@@ -59,7 +59,7 @@ pub struct LogPacket {
     ///
     /// A mark used through the netfilter, working as kind of scratch memory. 0 and no mark set are
     /// considered equivalent.
-    pub mark: u16,
+    pub mark: u32,
     /// A timestamp when the packet has been captured.
     pub timestamp: SystemTime,
     /// Source hardware address (eg. MAC).
@@ -140,7 +140,7 @@ impl Nl for LogPacket {
 
         for attr in attrs {
             match attr.nla_type {
-                NfLogAttr::Mark => result.mark = attr.get_payload_as()?,
+                NfLogAttr::Mark => result.mark = u32::from_be(attr.get_payload_as()?),
                 NfLogAttr::Timestamp => {
                     result.timestamp = attr.get_payload_as::<Timestamp>()?.into();
                 }


### PR DESCRIPTION
* All marks in iptables/netfilter are 32 bit everywhere.
* According to experiments, it seems to be big endian.

(Sorry for all these little fixes, I didn't get it right the first time because the netlink/netfilter documentation is somewhat lacking)