### PR TITLE
Add debug logging to neli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,23 @@ jobs:
       script:
         - cargo build
         - cargo build --features=stream
+        - cargo build --features=logging
+        - cargo build --all-features
         - cargo test
         - cargo test --features=stream
+        - cargo test --features=logging
+        - cargo test --all-features
     - stage: test
       rust: nightly
       script:
         - cargo build
         - cargo build --features=stream
+        - cargo build --features=logging
+        - cargo build --all-features
         - cargo test
         - cargo test --features=stream
+        - cargo test --features=logging
+        - cargo test --all-features
     - stage: test
       before_install:
         - docker pull jbaublitz/ubuntu-musl
@@ -36,8 +44,12 @@ jobs:
           /root/.cargo/bin/rustup default stable-x86_64-unknown-linux-musl &&
           /root/.cargo/bin/cargo build &&
           /root/.cargo/bin/cargo build --features=stream &&
+          /root/.cargo/bin/cargo build --features=logging &&
+          /root/.cargo/bin/cargo build --all-features &&
           /root/.cargo/bin/cargo test &&
-          /root/.cargo/bin/cargo test --features=stream"
+          /root/.cargo/bin/cargo test --features=stream &&
+          /root/.cargo/bin/cargo test --features=logging &&
+          /root/.cargo/bin/cargo test --all-features"
     - stage: test
       before_install:
         - docker pull jbaublitz/ubuntu-musl
@@ -48,5 +60,9 @@ jobs:
           /root/.cargo/bin/rustup default nightly-x86_64-unknown-linux-musl &&
           /root/.cargo/bin/cargo build &&
           /root/.cargo/bin/cargo build --features=stream &&
+          /root/.cargo/bin/cargo build --features=logging &&
+          /root/.cargo/bin/cargo build --all-features &&
           /root/.cargo/bin/cargo test &&
-          /root/.cargo/bin/cargo test --features=stream"
+          /root/.cargo/bin/cargo test --features=stream &&
+          /root/.cargo/bin/cargo test --features=logging &&
+          /root/.cargo/bin/cargo test --all-features"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,18 @@ path = "src/lib.rs"
 byteorder = "1.2"
 libc = "0.2.66"
 
+[dependencies.log]
+version = "0.4"
+optional = true
+
+[dependencies.simple_logger]
+version = "1.6.0"
+optional = true
+
+[dependencies.lazy_static]
+version = "1.4"
+optional = true
+
 [dependencies.tokio]
 version = "0.2"
 features = ["io-driver", "stream"]
@@ -37,3 +49,4 @@ features = ["copy"]
 [features]
 default = []
 stream = ["tokio", "mio"]
+logging = ["log", "simple_logger", "lazy_static"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -34,3 +34,4 @@ path = ".."
 
 [features]
 stream = ["tokio", "neli/stream"]
+logging = ["neli/logging"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,12 +93,8 @@ pub const MAX_NL_LENGTH: usize = 32768;
 #[cfg(feature = "logging")]
 lazy_static! {
     static ref LOGGING_INITIALIZED: bool =
-        if let Err(e) = simple_logger::init_with_level(log::Level::Trace) {
-            println!("Logger failed to initialize: {}; neli logging disabled.", e);
-            false
-        } else {
-            true
-        };
+        simple_logger::init_with_level(log::Level::Debug).is_ok();
+    static ref SHOW_LOGS: bool = std::env::var("NELI_LOG").is_ok();
 }
 
 /// Logging mechanism for neli for debugging
@@ -106,10 +102,10 @@ lazy_static! {
 #[macro_export]
 macro_rules! log {
     ($fmt:tt, $($args:expr),*) => {
-        if *$crate::LOGGING_INITIALIZED {
+        if *$crate::LOGGING_INITIALIZED && *$crate::SHOW_LOGS {
             log::debug!(concat!($fmt, "\n{}"), $($args),*, ["-"; 80].join(""));
         } else {
-            println!(concat!($fmt, "\n{}"), $($args),*, ["-"; 80].join(""));
+            ()
         }
     }
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,10 @@
+all: base ubuntu-musl-build rust-musl-ci-build
+
+base:
+	sudo docker pull ubuntu
+
+ubuntu-musl-build:
+	sudo docker build --no-cache -t ubuntu-musl ubuntu-musl
+
+rust-musl-ci-build:
+	sudo docker build --no-cache -t rust-musl-ci rust-musl-ci


### PR DESCRIPTION
This PR adds the ability to compile neli with the `logging` feature to add output for all of the messages sent and received. This should be extremely useful for debugging.

The reason this targets 0.5.0 is that it requires a small breaking change for the API to require all data structures being used with `send_nl` and `recv_nl` to implement `Debug`.