### PR TITLE
Fix bug in sequencing handling

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -351,9 +351,6 @@ impl NlSocket {
             // PID doesn't match
             Some(_) => return Err(NlError::BadPid),
         }
-        if let Some(seq) = self.seq.as_mut() {
-            *seq += 1;
-        }
         if self.buffer.as_ref().map(|b| b.at_end()).unwrap_or(false) {
             self.buffer = None;
         }


### PR DESCRIPTION
Sequence numbers are used for two purposes from what I can tell. One is associating a set of response messages with a request message. The other is an incrementing counter when subscribing to a multicast group stream. As a result, recv_nl should never increment the counter when receiving a message as send_nl will increment it when sending it. All responses should have the same sequence number as the request. In the case of multicast groups, no ACKs are sent so no increment operations are needed.