### PR TITLE
Remove IntoRawFd

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -420,9 +420,9 @@ impl AsRawFd for NlSocket {
 }
 
 impl IntoRawFd for NlSocket {
-    fn into_raw_fd(mut self) -> RawFd {
+    fn into_raw_fd(self) -> RawFd {
         let fd = self.fd;
-        self.fd = -1; // Prevent drop from closing it.
+        std::mem::forget(self);
         fd
     }
 }
@@ -689,15 +689,6 @@ mod test {
                 panic!("Should not return data");
             }
         }
-    }
-
-    #[test]
-    fn test_into_from_raw_fd() {
-        let s1 = NlSocket::connect(NlFamily::Generic, None, None, false).unwrap();
-        let fd = s1.into_raw_fd();
-        let s2 = unsafe { NlSocket::from_raw_fd(fd) };
-        // We send nonsense to the kernel, but we should still be able to send it
-        s2.send(b"X", 0).unwrap();
     }
 
     #[test]

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -659,10 +659,8 @@ pub mod tokio {
 impl Drop for NlSocket {
     /// Closes underlying file descriptor to avoid file descriptor leaks.
     fn drop(&mut self) {
-        if self.fd != -1 {
-            unsafe {
-                libc::close(self.fd);
-            }
+        unsafe {
+            libc::close(self.fd);
         }
     }
 }


### PR DESCRIPTION
PR revisions for #66 

@vorner I really don't think `IntoRawFd` should have been implemented in the first place. I really don't feel good about leaking IO resources so I'm going to remove it altogether. `AsRawFd` should do almost exactly the same thing without breaking resource cleanup. Is there a reason you were looking for this functionality? If so could you provide me with an example?

Either way, thank you for bringing this to my attention!