### PR TITLE
rtnl: Add example to get all routable IPs

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,6 +21,10 @@ name = "genl_stream"
 path = "genl_stream.rs"
 
 [[bin]]
+name = "getips"
+path = "getips.rs"
+
+[[bin]]
 name = "route-list"
 path = "route-list.rs"
 

--- a/examples/getips.rs
+++ b/examples/getips.rs
@@ -1,0 +1,62 @@
+extern crate neli;
+
+use std::net::Ipv4Addr;
+
+use neli::attr::Attribute;
+use neli::consts::nl::{NlmF, NlmFFlags};
+use neli::consts::rtnl::{Ifa, IfaFFlags, RtAddrFamily, RtScope, Rtm};
+use neli::consts::socket::NlFamily;
+use neli::err::NlError;
+use neli::nl::{NlPayload, Nlmsghdr};
+use neli::rtnl::Ifaddrmsg;
+use neli::socket::NlSocketHandle;
+use neli::types::RtBuffer;
+use neli::utils::U32Bitmask;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut rtnl = NlSocketHandle::connect(NlFamily::Route, None, U32Bitmask::empty())?;
+    let ifaddrmsg = Ifaddrmsg {
+        ifa_family: RtAddrFamily::Inet,
+        ifa_prefixlen: 0,
+        ifa_flags: IfaFFlags::empty(),
+        ifa_scope: 0,
+        ifa_index: 0,
+        rtattrs: RtBuffer::new(),
+    };
+    let nl_header = Nlmsghdr::new(
+        None,
+        Rtm::Getaddr,
+        NlmFFlags::new(&[NlmF::Request, NlmF::Root]),
+        None,
+        None,
+        NlPayload::Payload(ifaddrmsg),
+    );
+    rtnl.send(nl_header)?;
+    let mut addrs = Vec::<Ipv4Addr>::with_capacity(1);
+    for response in rtnl.iter(false) {
+        let header: Nlmsghdr<_, Ifaddrmsg> = response?;
+        if header.nl_type != Rtm::Newaddr.into() {
+            return Err(Box::new(NlError::new(
+                "Netlink error retrieving IP address",
+            )));
+        }
+        let msg = header.get_payload()?;
+        if RtScope::from(msg.ifa_scope) != RtScope::Universe {
+            continue;
+        }
+        for rtattr in msg.rtattrs.iter() {
+            if rtattr.rta_type == Ifa::Local {
+                addrs.push(Ipv4Addr::from(u32::from_be(
+                    rtattr.get_payload_as::<u32>()?,
+                )));
+            }
+        }
+    }
+
+    println!("Local IPv4 addresses:");
+    for addr in addrs {
+        println!("{}", addr);
+    }
+
+    Ok(())
+}

--- a/src/consts/rtnl.rs
+++ b/src/consts/rtnl.rs
@@ -372,10 +372,37 @@ impl_flags!(
     #[allow(missing_docs)]
     pub IffFlags, Iff, libc::c_uint
 );
+
 impl_flags!(
     #[allow(missing_docs)]
     pub IfaFFlags, IfaF, libc::c_uint
 );
+
+impl std::convert::TryFrom<&IfaFFlags> for libc::c_uchar {
+    type Error = std::num::TryFromIntError;
+    fn try_from(flags: &IfaFFlags) -> Result<libc::c_uchar, Self::Error> {
+        let mut n: libc::c_uint = 0;
+        for bit in 0..std::mem::size_of::<libc::c_uint>() * 8 {
+            if flags.contains(&IfaF::from(1 << bit)) {
+                n |= 1 << bit;
+            }
+        }
+        libc::c_uchar::try_from(n)
+    }
+}
+
+impl std::convert::From<libc::c_uchar> for IfaFFlags {
+    fn from(byte: libc::c_uchar) -> Self {
+        let mut flags = Self::empty();
+        for bit in 0..8 {
+            if byte & (1 << bit) != 0 {
+                flags.set(IfaF::from(1 << bit))
+            }
+        }
+        flags
+    }
+}
+
 impl_flags!(
     #[allow(missing_docs)]
     pub RtmFFlags, RtmF, libc::c_uint


### PR DESCRIPTION
This example also demonstrates how to read a netlink message
generically, and interpret differently depending on its type, using
`StreamReadBuffer` and `Nl::deserialize`.