### PR TITLE
Add Ndmsg::new function to initialize Ndmsg

### DIFF
--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -401,6 +401,29 @@ pub struct Ndmsg {
     pub rtattrs: RtBuffer<Nda, Buffer>,
 }
 
+impl Ndmsg {
+    /// Create a fully initialized neighbor table struct
+    pub fn new(
+        ndm_family: RtAddrFamily,
+        ndm_index: libc::c_int,
+        ndm_state: NudFlags,
+        ndm_flags: NtfFlags,
+        ndm_type: Rtn,
+        rtattrs: RtBuffer<Nda, Buffer>,
+    ) -> Self {
+        Ndmsg {
+            ndm_family,
+            pad1: 0,
+            pad2: 0,
+            ndm_index,
+            ndm_state,
+            ndm_flags,
+            ndm_type,
+            rtattrs,
+        }
+    }
+}
+
 impl Nl for Ndmsg {
     fn serialize(&self, mem: SerBuffer) -> Result<(), SerError> {
         serialize! {


### PR DESCRIPTION
Commit a53abe0ed416040b5edd9f7c5e0d5f05fbab6eb5 introduced two non-public fields to `Ndmsg` struct (`pad1` and `pad2`). This has made it impossible to construct `Ndmsg` struct outside `neli` from version 0.5 and later. This PR introduces `Ndmsg::new()` method to construct the struct.