### PR TITLE
Fix for set/getsockopt wrappers for netlink sockets

### DIFF
--- a/examples/ctrl-list.rs
+++ b/examples/ctrl-list.rs
@@ -6,7 +6,6 @@ use neli::{
     nl::{NlPayload, Nlmsghdr},
     socket::NlSocketHandle,
     types::{Buffer, GenlBuffer},
-    utils::U32Bitmask,
 };
 
 const GENL_VERSION: u8 = 2;
@@ -15,7 +14,7 @@ const GENL_VERSION: u8 = 2;
 // the name and identifier of each generic netlink family.
 
 fn main() -> Result<(), NlError> {
-    let mut socket = NlSocketHandle::connect(NlFamily::Generic, None, U32Bitmask::empty())?;
+    let mut socket = NlSocketHandle::connect(NlFamily::Generic, None, &[])?;
 
     let attrs = GenlBuffer::<NlAttrTypeWrapper, Buffer>::new();
     let genlhdr = Genlmsghdr::new(CtrlCmd::Getfamily, GENL_VERSION, attrs);

--- a/examples/custom_generic_nl_family_custom_types.rs
+++ b/examples/custom_generic_nl_family_custom_types.rs
@@ -21,7 +21,6 @@ use neli::{
     nl::{NlPayload, Nlmsghdr},
     socket::NlSocketHandle,
     types::{Buffer, GenlBuffer},
-    utils::U32Bitmask,
 };
 use std::process;
 
@@ -60,7 +59,7 @@ fn main() {
         NlFamily::Generic,
         // 0 is pid of kernel -> socket is connected to kernel
         Some(0),
-        U32Bitmask::empty(),
+        &[],
     )
     .unwrap();
 

--- a/examples/error_packet.rs
+++ b/examples/error_packet.rs
@@ -1,13 +1,10 @@
 use std::error::Error;
 
-use neli::{
-    consts::socket::NlFamily, err::NlError, genl::Genlmsghdr, socket::NlSocketHandle,
-    utils::U32Bitmask,
-};
+use neli::{consts::socket::NlFamily, err::NlError, genl::Genlmsghdr, socket::NlSocketHandle};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Create a socket and connect to generic netlink.
-    let mut sock = NlSocketHandle::connect(NlFamily::Generic, None, U32Bitmask::empty())?;
+    let mut sock = NlSocketHandle::connect(NlFamily::Generic, None, &[])?;
     // Attempt to resolve a multicast group that should not exist.
     let error = sock.resolve_nl_mcast_group("not_a", "group");
     match error {

--- a/examples/getips.rs
+++ b/examples/getips.rs
@@ -12,11 +12,10 @@ use neli::{
     rtnl::Ifaddrmsg,
     socket::NlSocketHandle,
     types::RtBuffer,
-    utils::U32Bitmask,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rtnl = NlSocketHandle::connect(NlFamily::Route, None, U32Bitmask::empty())?;
+    let mut rtnl = NlSocketHandle::connect(NlFamily::Route, None, &[])?;
     let ifaddrmsg = Ifaddrmsg {
         ifa_family: RtAddrFamily::Inet,
         ifa_prefixlen: 0,

--- a/examples/lookup_id.rs
+++ b/examples/lookup_id.rs
@@ -3,10 +3,10 @@ extern crate neli;
 use std::env;
 use std::error::Error;
 
-use neli::{consts::socket::NlFamily, err::NlError, socket::NlSocketHandle, utils::U32Bitmask};
+use neli::{consts::socket::NlFamily, err::NlError, socket::NlSocketHandle};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let mut sock = NlSocketHandle::connect(NlFamily::Generic, None, U32Bitmask::empty())?;
+    let mut sock = NlSocketHandle::connect(NlFamily::Generic, None, &[])?;
     let id = env::args()
         .nth(1)
         .ok_or_else(|| NlError::new("Integer argument required"))

--- a/examples/neli.rs
+++ b/examples/neli.rs
@@ -6,19 +6,18 @@ use neli::{
     nl::{NlPayload, Nlmsghdr},
     socket::*,
     types::GenlBuffer,
-    utils::U32Bitmask,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Resolve generic netlink family ID
     let family_name = "your_family_name_here";
-    let mut sock = NlSocketHandle::connect(NlFamily::Generic, None, U32Bitmask::empty()).unwrap();
+    let mut sock = NlSocketHandle::connect(NlFamily::Generic, None, &[]).unwrap();
     let _id = sock.resolve_genl_family(family_name).unwrap();
 
     // Resolve generic netlink multicast group ID
     let family_name = "your_family_name_here";
     let group_name = "your_group_name_here";
-    let mut sock = NlSocketHandle::connect(NlFamily::Generic, None, U32Bitmask::empty()).unwrap();
+    let mut sock = NlSocketHandle::connect(NlFamily::Generic, None, &[]).unwrap();
     let _id = sock
         .resolve_nl_mcast_group(family_name, group_name)
         .unwrap();

--- a/examples/route-list.rs
+++ b/examples/route-list.rs
@@ -9,7 +9,6 @@ use neli::{
     rtnl::*,
     socket::*,
     types::RtBuffer,
-    utils::U32Bitmask,
 };
 
 fn parse_route_table(rtm: Nlmsghdr<NlTypeWrapper, Rtmsg>) -> Result<(), NlError> {
@@ -67,7 +66,7 @@ fn parse_route_table(rtm: Nlmsghdr<NlTypeWrapper, Rtmsg>) -> Result<(), NlError>
 /// This sample is a simple imitation of the `ip route` command, to demonstrate interaction
 /// with the rtnetlink subsystem.  
 fn main() -> Result<(), Box<dyn Error>> {
-    let mut socket = NlSocketHandle::connect(NlFamily::Route, None, U32Bitmask::empty()).unwrap();
+    let mut socket = NlSocketHandle::connect(NlFamily::Route, None, &[]).unwrap();
 
     let rtmsg = Rtmsg {
         rtm_family: RtAddrFamily::Inet,

--- a/src/genl.rs
+++ b/src/genl.rs
@@ -419,7 +419,7 @@ mod test {
             socket::NlFamily,
         },
         socket::NlSocketHandle,
-        utils::{serialize, U32Bitmask},
+        utils::serialize,
     };
 
     #[test]
@@ -487,7 +487,7 @@ mod test {
     #[test]
     #[ignore]
     pub fn test_resolve_genl_family() {
-        let mut s = NlSocketHandle::connect(NlFamily::Generic, None, U32Bitmask::empty()).unwrap();
+        let mut s = NlSocketHandle::connect(NlFamily::Generic, None, &[]).unwrap();
         let id = s.resolve_genl_family("acpi_event").unwrap();
         assert_eq!(23, id)
     }
@@ -495,7 +495,7 @@ mod test {
     #[test]
     #[ignore]
     pub fn test_resolve_mcast_group() {
-        let mut s = NlSocketHandle::connect(NlFamily::Generic, None, U32Bitmask::empty()).unwrap();
+        let mut s = NlSocketHandle::connect(NlFamily::Generic, None, &[]).unwrap();
         let id = s
             .resolve_nl_mcast_group("acpi_event", "acpi_mc_group")
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@
 //!     nl::{Nlmsghdr, NlPayload},
 //!     socket::NlSocketHandle,
 //!     types::{Buffer, GenlBuffer},
-//!     utils::U32Bitmask,
 //! };
 //!
 //! const GENL_VERSION: u8 = 1;
@@ -72,7 +71,7 @@
 //!     let mut socket = NlSocketHandle::connect(
 //!         NlFamily::Generic,
 //!         None,
-//!         U32Bitmask::empty(),
+//!         &[],
 //!     )?;
 //!
 //!     let attrs: GenlBuffer<Index, Buffer> = GenlBuffer::new();
@@ -115,20 +114,19 @@
 //!     err::NlError,
 //!     genl::Genlmsghdr,
 //!     socket,
-//!     utils::{U32BitFlag, U32Bitmask},
 //! };
 //!
 //! fn subscribe_to_mcast() -> Result<(), Box<dyn Error>> {
 //!     let mut s = socket::NlSocketHandle::connect(
 //!         NlFamily::Generic,
 //!         None,
-//!         U32Bitmask::empty(),
+//!         &[],
 //!     )?;
 //!     let id = s.resolve_nl_mcast_group(
 //!         "my_family_name",
 //!         "my_multicast_group_name",
 //!     )?;
-//!     s.add_mcast_membership(U32Bitmask::from(U32BitFlag::new(id)?))?;
+//!     s.add_mcast_membership(&[id])?;
 //!     for next in s.iter::<Genlmsghdr<u8, u16>>(true) {
 //!         // Do stuff here with parsed packets...
 //!     

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -51,7 +51,7 @@ use crate::{
     nl::{NlPayload, Nlmsghdr},
     parse::packet_length_u32,
     types::{GenlBuffer, NlBuffer, SockBuffer},
-    utils::U32Bitmask,
+    utils::NetlinkBitArray,
     Nl,
 };
 
@@ -74,11 +74,7 @@ impl NlSocket {
     }
 
     /// Equivalent of `socket` and `bind` calls.
-    pub fn connect(
-        proto: NlFamily,
-        pid: Option<u32>,
-        groups: U32Bitmask,
-    ) -> Result<Self, io::Error> {
+    pub fn connect(proto: NlFamily, pid: Option<u32>, groups: &[u32]) -> Result<Self, io::Error> {
         let s = NlSocket::new(proto)?;
         s.bind(pid, groups)?;
         Ok(s)
@@ -124,7 +120,7 @@ impl NlSocket {
     /// Use this function to bind to a netlink ID and subscribe to
     /// groups. See netlink(7) man pages for more information on
     /// netlink IDs and groups.
-    pub fn bind(&self, pid: Option<u32>, groups: U32Bitmask) -> Result<(), io::Error> {
+    pub fn bind(&self, pid: Option<u32>, groups: &[u32]) -> Result<(), io::Error> {
         let mut nladdr = unsafe { zeroed::<libc::sockaddr_nl>() };
         nladdr.nl_family = libc::c_int::from(AddrFamily::Netlink) as u16;
         nladdr.nl_pid = pid.unwrap_or(0);
@@ -146,53 +142,75 @@ impl NlSocket {
     }
 
     /// Join multicast groups for a socket.
-    pub fn add_mcast_membership(&self, groups: U32Bitmask) -> Result<(), io::Error> {
-        match unsafe {
-            libc::setsockopt(
-                self.fd,
-                libc::SOL_NETLINK,
-                libc::NETLINK_ADD_MEMBERSHIP,
-                &*groups as *const _ as *const libc::c_void,
-                size_of::<u32>() as libc::socklen_t,
-            )
-        } {
-            i if i == 0 => Ok(()),
-            _ => Err(io::Error::last_os_error()),
+    pub fn add_mcast_membership(&self, groups: &[u32]) -> Result<(), io::Error> {
+        for group in groups {
+            match unsafe {
+                libc::setsockopt(
+                    self.fd,
+                    libc::SOL_NETLINK,
+                    libc::NETLINK_ADD_MEMBERSHIP,
+                    group as *const _ as *const libc::c_void,
+                    size_of::<u32>() as libc::socklen_t,
+                )
+            } {
+                i if i == 0 => (),
+                _ => return Err(io::Error::last_os_error()),
+            }
         }
+        Ok(())
     }
 
     /// Leave multicast groups for a socket.
-    pub fn drop_mcast_membership(&self, groups: U32Bitmask) -> Result<(), io::Error> {
-        match unsafe {
-            libc::setsockopt(
-                self.fd,
-                libc::SOL_NETLINK,
-                libc::NETLINK_DROP_MEMBERSHIP,
-                &*groups as *const _ as *const libc::c_void,
-                size_of::<u32>() as libc::socklen_t,
-            )
-        } {
-            i if i == 0 => Ok(()),
-            _ => Err(io::Error::last_os_error()),
+    pub fn drop_mcast_membership(&self, groups: &[u32]) -> Result<(), io::Error> {
+        for group in groups {
+            match unsafe {
+                libc::setsockopt(
+                    self.fd,
+                    libc::SOL_NETLINK,
+                    libc::NETLINK_DROP_MEMBERSHIP,
+                    group as *const _ as *const libc::c_void,
+                    (groups.len() * size_of::<u32>()) as libc::socklen_t,
+                )
+            } {
+                i if i == 0 => (),
+                _ => return Err(io::Error::last_os_error()),
+            }
         }
+        Ok(())
     }
 
     /// List joined groups for a socket.
-    pub fn list_mcast_membership(&self) -> Result<U32Bitmask, io::Error> {
-        let mut grps = 0u32;
-        let mut len = size_of::<u32>() as libc::socklen_t;
-        match unsafe {
+    pub fn list_mcast_membership(&self) -> Result<NetlinkBitArray, io::Error> {
+        let mut bit_array = NetlinkBitArray::new(4);
+        let mut len = bit_array.len();
+        if unsafe {
             libc::getsockopt(
                 self.fd,
                 libc::SOL_NETLINK,
                 libc::NETLINK_LIST_MEMBERSHIPS,
-                &mut grps as *mut _ as *mut libc::c_void,
+                bit_array.as_mut_slice() as *mut _ as *mut libc::c_void,
                 &mut len as *mut _ as *mut libc::socklen_t,
             )
-        } {
-            i if i == 0 => Ok(U32Bitmask::from(grps)),
-            _ => Err(io::Error::last_os_error()),
+        } != 0
+        {
+            return Err(io::Error::last_os_error());
         }
+        if len > bit_array.len() {
+            bit_array.resize(len);
+            if unsafe {
+                libc::getsockopt(
+                    self.fd,
+                    libc::SOL_NETLINK,
+                    libc::NETLINK_LIST_MEMBERSHIPS,
+                    bit_array.as_mut_slice() as *mut _ as *mut libc::c_void,
+                    &mut len as *mut _ as *mut libc::socklen_t,
+                )
+            } != 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(bit_array)
     }
 
     /// Send message encoded as byte slice to the netlink ID
@@ -293,11 +311,7 @@ impl NlSocketHandle {
     }
 
     /// Equivalent of `socket` and `bind` calls.
-    pub fn connect(
-        proto: NlFamily,
-        pid: Option<u32>,
-        groups: U32Bitmask,
-    ) -> Result<Self, io::Error> {
+    pub fn connect(proto: NlFamily, pid: Option<u32>, groups: &[u32]) -> Result<Self, io::Error> {
         Ok(NlSocketHandle {
             socket: NlSocket::connect(proto, pid, groups)?,
             buffer: SockBuffer::new(),
@@ -325,22 +339,22 @@ impl NlSocketHandle {
     /// Use this function to bind to a netlink ID and subscribe to
     /// groups. See netlink(7) man pages for more information on
     /// netlink IDs and groups.
-    pub fn bind(&self, pid: Option<u32>, groups: U32Bitmask) -> Result<(), io::Error> {
+    pub fn bind(&self, pid: Option<u32>, groups: &[u32]) -> Result<(), io::Error> {
         self.socket.bind(pid, groups)
     }
 
     /// Join multicast groups for a socket.
-    pub fn add_mcast_membership(&self, groups: U32Bitmask) -> Result<(), io::Error> {
+    pub fn add_mcast_membership(&self, groups: &[u32]) -> Result<(), io::Error> {
         self.socket.add_mcast_membership(groups)
     }
 
     /// Leave multicast groups for a socket.
-    pub fn drop_mcast_membership(&self, groups: U32Bitmask) -> Result<(), io::Error> {
+    pub fn drop_mcast_membership(&self, groups: &[u32]) -> Result<(), io::Error> {
         self.socket.drop_mcast_membership(groups)
     }
 
     /// List joined groups for a socket.
-    pub fn list_mcast_membership(&self) -> Result<U32Bitmask, io::Error> {
+    pub fn list_mcast_membership(&self) -> Result<NetlinkBitArray, io::Error> {
         self.socket.list_mcast_membership()
     }
 
@@ -497,8 +511,13 @@ impl NlSocketHandle {
         Ok(())
     }
 
-    /// Convenience function to begin receiving a stream of
-    /// [`Nlmsghdr`][crate::nl::Nlmsghdr] structs.
+    /// Convenience function to read a stream of
+    /// [`Nlmsghdr`][crate::nl::Nlmsghdr] structs one by one.
+    /// Use [`NlSocketHandle::iter`] or [`NlSockHandle::iter2`]
+    /// instead for easy iteration over returned packets.
+    ///
+    /// Returns [`None`] only in non-blocking contexts if no
+    /// message can be immediately returned.
     pub fn recv<T, P>(&mut self) -> Result<Option<Nlmsghdr<T, P>>, NlError>
     where
         T: Nl + NlType + Debug,
@@ -838,8 +857,7 @@ pub mod tokio {
 
         #[test]
         fn test_socket_send() {
-            let s =
-                socket::NlSocket::connect(NlFamily::Generic, None, U32Bitmask::empty()).unwrap();
+            let s = socket::NlSocket::connect(NlFamily::Generic, None, &[]).unwrap();
             let runtime = Runtime::new().unwrap();
             runtime
                 .block_on(async move {
@@ -923,5 +941,21 @@ mod test {
         nl.push(nl_next1);
         nl.push(nl_next2);
         assert_eq!(nl, v);
+    }
+
+    #[test]
+    fn real_test_mcast_groups() {
+        let mut sock = NlSocketHandle::new(NlFamily::Generic).unwrap();
+        let notify_id = sock.resolve_nl_mcast_group("nlctrl", "notify").unwrap();
+        let nl80211_id = sock.resolve_nl_mcast_group("nl80211", "scan").unwrap();
+        sock.add_mcast_membership(&[notify_id, nl80211_id]).unwrap();
+        let groups = sock.list_mcast_membership().unwrap();
+        assert!(groups.is_set(notify_id as usize));
+        assert!(groups.is_set(nl80211_id as usize));
+        sock.drop_mcast_membership(&[notify_id, nl80211_id])
+            .unwrap();
+        let groups = sock.list_mcast_membership().unwrap();
+        assert!(!groups.is_set(notify_id as usize));
+        assert!(!groups.is_set(nl80211_id as usize));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,147 +6,9 @@
 //! are handled internally in the types so that the user does not
 //! have to be aware of them.
 
-use std::{
-    error::Error,
-    fmt::{self, Display},
-    ops::{BitOr, BitOrAssign, Deref},
-};
+use std::mem::size_of;
 
 use crate::{err::SerError, Nl};
-
-/// Represents an error for operations on bitmasks if the integer
-/// that is being used to store the bitmask cannot represent the
-/// result of requested operation.
-#[derive(Debug)]
-pub struct BitRepError(String);
-
-impl BitRepError {
-    fn new<D>(message: D) -> Self
-    where
-        D: Display,
-    {
-        BitRepError(message.to_string())
-    }
-}
-
-impl Error for BitRepError {}
-
-impl Display for BitRepError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// Struct representing a single bit flag
-#[derive(Copy, Clone)]
-pub struct U32BitFlag(u32);
-
-impl U32BitFlag {
-    /// Create a new bitflag from the index of the bit to set.
-    pub fn new(bit_num: u32) -> Result<Self, BitRepError> {
-        if bit_num > 32 {
-            return Err(BitRepError::new(
-                "You specified a bit beyond the 32 bit \
-                 representation of a u32",
-            ));
-        }
-        Ok(U32BitFlag(bit_num))
-    }
-
-    /// Convert this bitflag into a bitmask with only this bit set.
-    fn into_bitmask(self) -> U32Bitmask {
-        U32Bitmask::from(num_to_set_mask(self.0))
-    }
-}
-
-/// Struct for handling [`u32`] bitmask operations
-pub struct U32Bitmask(u32);
-
-impl U32Bitmask {
-    /// Create an empty bitmask
-    pub fn empty() -> Self {
-        U32Bitmask(0)
-    }
-
-    /// Return [`true`] if the bitmask is empty
-    pub fn is_empty(&self) -> bool {
-        self.0 == 0
-    }
-
-    /// Check if the bit at position `bit` is set - returns false
-    /// for anything larger than 32 as that extends past the
-    /// boundaries of a 32 bit integer bitmask
-    pub fn is_set(&self, bit: u32) -> bool {
-        if bit > 32 {
-            return false;
-        }
-        let set_mask = num_to_set_mask(bit);
-        set_mask & self.0 == set_mask
-    }
-}
-
-impl BitOr<U32Bitmask> for U32Bitmask {
-    type Output = U32Bitmask;
-
-    fn bitor(self, rhs: U32Bitmask) -> Self::Output {
-        U32Bitmask::from(self.0 | *rhs)
-    }
-}
-
-impl BitOr<U32BitFlag> for U32Bitmask {
-    type Output = U32Bitmask;
-
-    fn bitor(self, rhs: U32BitFlag) -> Self::Output {
-        self | rhs.into_bitmask()
-    }
-}
-
-impl BitOr<U32Bitmask> for U32BitFlag {
-    type Output = U32Bitmask;
-
-    fn bitor(self, rhs: U32Bitmask) -> Self::Output {
-        self.into_bitmask() | rhs
-    }
-}
-
-impl<'a> BitOrAssign<&'a U32BitFlag> for U32Bitmask {
-    fn bitor_assign(&mut self, rhs: &U32BitFlag) {
-        self.0 |= *U32Bitmask::from(*rhs)
-    }
-}
-
-impl<'a> BitOrAssign<&'a U32BitFlag> for &'a mut U32Bitmask {
-    fn bitor_assign(&mut self, rhs: &U32BitFlag) {
-        self.0 |= *U32Bitmask::from(*rhs)
-    }
-}
-
-impl From<U32BitFlag> for U32Bitmask {
-    fn from(v: U32BitFlag) -> Self {
-        v.into_bitmask()
-    }
-}
-
-impl From<u32> for U32Bitmask {
-    fn from(v: u32) -> Self {
-        U32Bitmask(v)
-    }
-}
-
-impl Deref for U32Bitmask {
-    type Target = u32;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// Conversion between a group number and the necessary bitmask
-/// to perform a bitwise OR that will set the bit
-#[inline]
-fn num_to_set_mask(grp: u32) -> u32 {
-    1 << (grp - 1)
-}
 
 /// Convenience method for allocating a buffer for serialization.
 pub fn serialize<N>(nl: &N, align: bool) -> Result<Vec<u8>, SerError>
@@ -157,4 +19,153 @@ where
     let mut vec = vec![0; len];
     nl.serialize(vec.as_mut_slice())?;
     Ok(vec)
+}
+
+type BitArrayType = u32;
+
+/// A bit array meant to be compatible with the bit array
+/// returned by the `NETLINK_LIST_MEMBERSHIPS` socket operation
+/// on netlink sockets.
+pub struct NetlinkBitArray(Vec<BitArrayType>);
+
+/// bittest/bitset instrinsics are not stable in Rust so this
+/// needs to be implemented this way.
+#[allow(clippy::len_without_is_empty)]
+impl NetlinkBitArray {
+    const BIT_SIZE: usize = size_of::<BitArrayType>() * 8;
+
+    /// Create a new bit array.
+    ///
+    /// This method will round `bit_len` up to the nearest
+    /// multiple of [`size_of::<u32>()`][std::mem::size_of].
+    pub fn new(bit_len: usize) -> Self {
+        let round = Self::BIT_SIZE - 1;
+        NetlinkBitArray(vec![0; ((bit_len + round) & !round) / Self::BIT_SIZE])
+    }
+
+    /// Resize the underlying vector to have enough space for
+    /// the nearest multiple of [`size_of::<u32>()`][std::mem::size_of]
+    /// rounded up.
+    pub fn resize_bits(&mut self, bit_len: usize) {
+        let round = Self::BIT_SIZE - 1;
+        self.0
+            .resize(((bit_len + round) & !round) / Self::BIT_SIZE, 0);
+    }
+
+    /// Resize the underlying vector to have enough space for
+    /// the nearest multiple of [`size_of::<
+    pub fn resize(&mut self, bytes: usize) {
+        let byte_round = size_of::<BitArrayType>() - 1;
+        self.0.resize(
+            ((bytes + byte_round) & !byte_round) / size_of::<BitArrayType>(),
+            0,
+        );
+    }
+
+    /// Returns true if the `n`th bit is set.
+    pub fn is_set(&self, n: usize) -> bool {
+        if n == 0 {
+            return false;
+        }
+        let n_1 = n - 1;
+        let bit_segment = self.0[n_1 / Self::BIT_SIZE];
+        let bit_shifted_n = 1 << (n_1 % Self::BIT_SIZE);
+        bit_segment & bit_shifted_n == bit_shifted_n
+    }
+
+    /// Set the `n`th bit.
+    pub fn set(&mut self, n: usize) {
+        if n == 0 {
+            return;
+        }
+        let n_1 = n - 1;
+        let bit_segment = self.0[n_1 / Self::BIT_SIZE];
+        let bit_shifted_n = 1 << (n_1 % Self::BIT_SIZE);
+        self.0[n_1 / Self::BIT_SIZE] = bit_segment | bit_shifted_n;
+    }
+
+    /// Get a vector representation of all of the bit positions set
+    /// to 1 in this bit array.
+    ///
+    /// ## Example
+    /// ```
+    /// use neli::utils::NetlinkBitArray;
+    ///
+    /// let mut array = NetlinkBitArray::new(24);
+    /// array.set(4);
+    /// array.set(7);
+    /// array.set(23);
+    /// assert_eq!(array.to_vec(), vec![4, 7, 23]);
+    /// ```
+    pub fn to_vec(&self) -> Vec<u32> {
+        let mut bits = Vec::new();
+        for bit in 0..self.len_bits() {
+            let bit_shifted = 1 << (bit % Self::BIT_SIZE);
+            if bit_shifted & self.0[bit / Self::BIT_SIZE] == bit_shifted {
+                bits.push(bit as u32 + 1);
+            }
+        }
+        bits
+    }
+
+    /// Return the number of bits that can be contained in this bit
+    /// array.
+    pub fn len_bits(&self) -> usize {
+        self.0.len() * Self::BIT_SIZE
+    }
+
+    /// Return the length in bytes for this bit array.
+    pub fn len(&self) -> usize {
+        self.0.len() * size_of::<BitArrayType>()
+    }
+
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [BitArrayType] {
+        self.0.as_mut_slice()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_bit_array() {
+        let mut bit_array = NetlinkBitArray::new(7);
+        assert_eq!(bit_array.0.len(), 1);
+        bit_array.set(4);
+        assert_eq!(bit_array.0[0], 0b1000);
+        assert_eq!(bit_array.is_set(4), true);
+        assert_eq!(bit_array.is_set(0), false);
+        assert_eq!(bit_array.is_set(1), false);
+        assert_eq!(bit_array.is_set(2), false);
+        assert_eq!(bit_array.is_set(3), false);
+
+        assert_eq!(bit_array.len(), 4);
+        assert_eq!(bit_array.len_bits(), 32);
+
+        let mut bit_array = NetlinkBitArray::new(33);
+        bit_array.set(32);
+        bit_array.set(33);
+        assert!(bit_array.0[0] == 1 << 31);
+        assert!(bit_array.0[1] == 1);
+        assert!(bit_array.is_set(32));
+        assert!(bit_array.is_set(33));
+
+        let mut bit_array = NetlinkBitArray::new(32);
+        assert_eq!(bit_array.len(), 4);
+        bit_array.resize_bits(33);
+        assert_eq!(bit_array.len(), 8);
+        bit_array.resize_bits(1);
+        assert_eq!(bit_array.len(), 4);
+
+        let mut bit_array = NetlinkBitArray::new(33);
+        assert_eq!(bit_array.len(), 8);
+        bit_array.resize(1);
+        assert_eq!(bit_array.len(), 4);
+        bit_array.resize(9);
+        assert_eq!(bit_array.len(), 12);
+
+        let bit_array = NetlinkBitArray(vec![8, 8, 8]);
+        assert_eq!(bit_array.to_vec(), vec![4, 36, 68]);
+    }
 }


### PR DESCRIPTION
Closes #141 

This includes a breaking change, but given that it is a bug fix, this will go into the next patch release.