### PR TITLE
getips: Don't ignore errors returned after iteration starts

### DIFF
--- a/examples/getips.rs
+++ b/examples/getips.rs
@@ -36,21 +36,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut addrs = Vec::<Ipv4Addr>::with_capacity(1);
     for response in rtnl.iter(false) {
         let header: Nlmsghdr<_, Ifaddrmsg> = response?;
-        if let NlPayload::Payload(p) = header.nl_payload {
-            if header.nl_type != Rtm::Newaddr.into() {
-                return Err(Box::new(NlError::new(
-                    "Netlink error retrieving IP address",
+        if let NlPayload::Empty = header.nl_payload {
+            continue;
+        }
+        if header.nl_type != Rtm::Newaddr.into() {
+            return Err(Box::new(NlError::new(
+                "Netlink error retrieving IP address",
+            )));
+        }
+        let p = header.get_payload()?;
+        if RtScope::from(p.ifa_scope) != RtScope::Universe {
+            continue;
+        }
+        for rtattr in p.rtattrs.iter() {
+            if rtattr.rta_type == Ifa::Local {
+                addrs.push(Ipv4Addr::from(u32::from_be(
+                    rtattr.get_payload_as::<u32>()?,
                 )));
-            }
-            if RtScope::from(p.ifa_scope) != RtScope::Universe {
-                continue;
-            }
-            for rtattr in p.rtattrs.iter() {
-                if rtattr.rta_type == Ifa::Local {
-                    addrs.push(Ipv4Addr::from(u32::from_be(
-                        rtattr.get_payload_as::<u32>()?,
-                    )));
-                }
             }
         }
     }


### PR DESCRIPTION
getips ignores anything that isn't an NlPayload::Payload, which includes
NlPayload::Err. Instead, skip over NlPayload::Empty but process other
errors as errors.