### PR TITLE
Fix bug of GenlBuffer Size implementation

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@
 //! cases to allow the internal representation to change without
 //! resulting in a breaking change.
 
-use crate as neli;
+use crate::{self as neli, consts::alignto};
 
 use std::{
     fmt::{self, Debug},
@@ -165,11 +165,16 @@ impl<T, P> Default for NlBuffer<T, P> {
 }
 
 /// A buffer of generic netlink attributes.
-#[derive(Debug, PartialEq, Size, ToBytes, FromBytesWithInput)]
+#[derive(Debug, PartialEq, ToBytes, FromBytesWithInput)]
 #[neli(to_bytes_bound = "T: NlAttrType")]
 #[neli(from_bytes_bound = "T: NlAttrType")]
 #[neli(from_bytes_bound = "P: FromBytesWithInput<Input = usize>")]
 pub struct GenlBuffer<T, P>(#[neli(input)] Vec<Nlattr<T, P>>);
+impl<T,P> neli::Size for GenlBuffer<T, P> {
+    fn unpadded_size(&self) -> usize {
+        self.0.iter().map(|attr|{alignto(attr.nla_len as usize)}).sum()
+    }
+}
 
 impl<T> GenlBuffer<T, Buffer> {
     /// Get a data structure with an immutable reference to the

--- a/src/types.rs
+++ b/src/types.rs
@@ -266,10 +266,16 @@ impl<T, P> Default for GenlBuffer<T, P> {
 }
 
 /// A buffer of rtnetlink attributes.
-#[derive(Debug, Size, FromBytesWithInput, ToBytes)]
+#[derive(Debug, FromBytesWithInput, ToBytes)]
 #[neli(from_bytes_bound = "T: RtaType")]
 #[neli(from_bytes_bound = "P: FromBytesWithInput<Input = usize>")]
 pub struct RtBuffer<T, P>(#[neli(input)] Vec<Rtattr<T, P>>);
+
+impl<T,P> neli::Size for RtBuffer<T, P> {
+    fn unpadded_size(&self) -> usize {
+        self.0.iter().map(|attr|{alignto(attr.rta_len as usize)}).sum()
+    }
+}
 
 impl<T> RtBuffer<T, Buffer> {
     /// Get a data structure with an immutable reference to the


### PR DESCRIPTION
Hi, I found that there is a bug in computation of `nlmsg_len` of a netlink package.

If we use generic netlink, the payload is in format of Type-Length-Value attribute. 
We must align the attributes to 4 bytes.
So the `nlmsg_len` should sum up all **aligned attributes**' size, but not sum up all attributes' size then align.

English is not my native language, and I apologize for any grammatical errors and improper wording.

Here is an example can produce the bug.
```rust
mod test {
    use neli::{
        consts::nl::{NlmF, NlmFFlags},
        genl::{Genlmsghdr, Nlattr},
        neli_enum,
        nl::{NlPayload, Nlmsghdr},
        types::{Buffer, GenlBuffer},
    };

    #[neli_enum(serialized_type = "u16")]
    enum SendAttribute {
        Unspec = 0,
        A = 1,
        B = 2,
    }
    impl neli::consts::genl::NlAttrType for SendAttribute {}

    #[test]
    fn test() {
        let mut attrs: GenlBuffer<SendAttribute, Buffer> = GenlBuffer::new();
        let attr_a = "123"; // 4 bytes
        let attr_b = "123";

        attrs.push(Nlattr::new(false, false, SendAttribute::A, attr_a).unwrap());
        attrs.push(Nlattr::new(false, false, SendAttribute::B, attr_b).unwrap());
        let gnmsghdr = Genlmsghdr::new(1, 1, attrs);

        let nlmsghdr = Nlmsghdr::new(
            None,
            1,
            NlmFFlags::new(&[NlmF::Request]),
            Some(0),
            Some(1),
            NlPayload::Payload(gnmsghdr),
        );
        assert_eq!(nlmsghdr.nl_len,36);

        let mut attrs: GenlBuffer<SendAttribute, Buffer> = GenlBuffer::new();
        let attr_a = "1234"; // 5 bytes, should take 8 bytes
        let attr_b = "123";

        attrs.push(Nlattr::new(false, false, SendAttribute::A, attr_a).unwrap());
        attrs.push(Nlattr::new(false, false, SendAttribute::B, attr_b).unwrap());
        let gnmsghdr = Genlmsghdr::new(1, 1, attrs);

        let nlmsghdr = Nlmsghdr::new(
            None,
            1,
            NlmFFlags::new(&[NlmF::Request]),
            Some(0),
            Some(1),
            NlPayload::Payload(gnmsghdr),
        );
        assert_eq!(nlmsghdr.nl_len,40);

        let mut attrs: GenlBuffer<SendAttribute, Buffer> = GenlBuffer::new();
        let attr_a = "1234";
        let attr_b = "1234";

        attrs.push(Nlattr::new(false, false, SendAttribute::A, attr_a).unwrap());
        attrs.push(Nlattr::new(false, false, SendAttribute::B, attr_b).unwrap());
        let gnmsghdr = Genlmsghdr::new(1, 1, attrs);

        let nlmsghdr = Nlmsghdr::new(
            None,
            1,
            NlmFFlags::new(&[NlmF::Request]),
            Some(0),
            Some(1),
            NlPayload::Payload(gnmsghdr),
        );
        assert_eq!(nlmsghdr.nl_len,44);
    }
}
```
