### PR TITLE
neli-proc-macros: Update required version of `syn`

### DIFF
--- a/neli-proc-macros/Cargo.toml
+++ b/neli-proc-macros/Cargo.toml
@@ -20,5 +20,5 @@ version = "1"
 features = ["derive"]
 
 [dependencies.syn]
-version = "1"
+version = "1.0.98"
 features = ["full", "extra-traits"]


### PR DESCRIPTION
neli-proc-macros does not compile with syn 1; it needs newer
functionality. Bump it to the current version.
