### PR TITLE
Default to native-endian in `Nlattr::new`; add `new_be` for network-endian

### DIFF
--- a/examples/create-nested-attributes.rs
+++ b/examples/create-nested-attributes.rs
@@ -15,8 +15,8 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     // As of v0.7.0, this can cause breakage due to the flag indicating whether an
     // attribute is nested is handled automatically.
     //
-    // let attrs = vec![Nlattr::new(false, 1, vec![Nlattr::new(false, 1, "this_family")?]),
-    //                  Nlattr::new(false, 2, vec![Nlattr::new(false, 1, "that_family")?])];
+    // let attrs = vec![Nlattr::new(1, vec![Nlattr::new(false, 1, "this_family")?]),
+    //                  Nlattr::new(2, vec![Nlattr::new(false, 1, "that_family")?])];
 
     // let genlmsg = Genlmsghdr::new(CtrlCmd::Getfamily, 2, attrs)?;
     // let nlmsg = Nlmsghdr::new(None, Nlmsg::Noop, vec![consts::NlmF::Request], None, None,
@@ -28,25 +28,25 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     // This is also discouraged because the following method does not work -
     // the payload type of one nested attribute is a &str while another is an integer value:
     //
-    // let attrs = vec![Nlattr::new(false, 1, vec![
-    //                Nlattr::new(false, 1, "this_family"),
-    //                Nlattr::new(false, 2, 0),
-    //           ]), Nlattr::new(false, 2, vec![
-    //                Nlattr::new(false, 1, "that_family"),
-    //                Nlattr::new(false, 2, 5),
+    // let attrs = vec![Nlattr::new(1, vec![
+    //                Nlattr::new(1, "this_family"),
+    //                Nlattr::new(2, 0),
+    //           ]), Nlattr::new(2, vec![
+    //                Nlattr::new(1, "that_family"),
+    //                Nlattr::new(2, 5),
     //            ])];
 
     // Instead, do the following:
-    let mut attr1 = Nlattr::new(false, 0, Vec::<u8>::new())?;
-    attr1.add_nested_attribute(&Nlattr::new(false, 1, "this is a string")?)?;
+    let mut attr1 = Nlattr::new(0, Vec::<u8>::new())?;
+    attr1.add_nested_attribute(&Nlattr::new(1, "this is a string")?)?;
     // This is not a string
-    attr1.add_nested_attribute(&Nlattr::new(false, 2, 0)?)?;
+    attr1.add_nested_attribute(&Nlattr::new(2, 0)?)?;
 
     // And again for another set of nested attributes
-    let mut attr2 = Nlattr::new(false, 2, Vec::<u8>::new())?;
-    attr2.add_nested_attribute(&Nlattr::new(false, 1, "this is also a string")?)?;
+    let mut attr2 = Nlattr::new(2, Vec::<u8>::new())?;
+    attr2.add_nested_attribute(&Nlattr::new(1, "this is also a string")?)?;
     // Not a string
-    attr2.add_nested_attribute(&Nlattr::new(false, 2, 5)?)?;
+    attr2.add_nested_attribute(&Nlattr::new(2, 5)?)?;
 
     let mut attrs = GenlBuffer::new();
     attrs.push(attr1);

--- a/examples/custom_generic_nl_family_custom_types.rs
+++ b/examples/custom_generic_nl_family_custom_types.rs
@@ -83,7 +83,6 @@ fn main() {
     let mut attrs: GenlBuffer<NlFoobarXmplAttribute, Buffer> = GenlBuffer::new();
     attrs.push(
         Nlattr::new(
-            false,
             // the type of the attribute. This is an u16 and corresponds
             // to an enum on the receiving side
             NlFoobarXmplAttribute::Msg,

--- a/examples/extack.rs
+++ b/examples/extack.rs
@@ -49,7 +49,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     attrs.push(
         Nlattr::new(
-            /* Network Byte Order */ false,
             /* Attribute */ Nl80211Attribute::Mac,
             /* Value */ vec![0_u8], /* NOTE: Deliberately wrong length */
         )

--- a/src/genl.rs
+++ b/src/genl.rs
@@ -215,7 +215,33 @@ where
 {
     /// Create a new `Nlattr` with parameters for setting bitflags
     /// in the header.
-    pub fn new<P>(nla_network_order: bool, nla_type: T, nla_payload: P) -> Result<Self, SerError>
+    ///
+    /// This uses native byte order. If you need to use network byte order, see [`new_be`].
+    pub fn new<P>(nla_type: T, nla_payload: P) -> Result<Self, SerError>
+    where
+        P: Size + ToBytes,
+    {
+        Nlattr::new_internal(false, nla_type, nla_payload)
+    }
+
+    /// Create a new `Nlattr` with parameters for setting bitflags
+    /// in the header.
+    ///
+    /// This uses network byte order. To use native byte order, see [`new`].
+    pub fn new_be<P>(nla_type: T, nla_payload: P) -> Result<Self, SerError>
+    where
+        P: Size + ToBytes,
+    {
+        Nlattr::new_internal(true, nla_type, nla_payload)
+    }
+
+    /// Create a new `Nlattr` with parameters for setting bitflags
+    /// in the header.
+    fn new_internal<P>(
+        nla_network_order: bool,
+        nla_type: T,
+        nla_payload: P,
+    ) -> Result<Self, SerError>
     where
         P: Size + ToBytes,
     {

--- a/src/genl.rs
+++ b/src/genl.rs
@@ -228,6 +228,9 @@ where
     /// in the header.
     ///
     /// This uses network byte order. To use native byte order, see [`new`].
+    ///
+    /// The payload type's serialization must handle any necessary byteswapping. neli's built-in
+    /// conversions handle that.
     pub fn new_be<P>(nla_type: T, nla_payload: P) -> Result<Self, SerError>
     where
         P: Size + ToBytes,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -395,7 +395,7 @@ impl NlSocketHandle {
 
     fn get_genl_family(&mut self, family_name: &str) -> GenlFamily {
         let mut attrs = GenlBuffer::new();
-        attrs.push(Nlattr::new(false, CtrlAttr::FamilyName, family_name)?);
+        attrs.push(Nlattr::new(CtrlAttr::FamilyName, family_name)?);
         let genlhdr = Genlmsghdr::new(CtrlCmd::Getfamily, 2, attrs);
         let nlhdr = Nlmsghdr::new(
             None,
@@ -856,8 +856,8 @@ mod test {
         setup();
 
         let mut attrs = GenlBuffer::new();
-        attrs.push(Nlattr::new(false, CtrlAttr::FamilyId, 5u32).unwrap());
-        attrs.push(Nlattr::new(false, CtrlAttr::FamilyName, "my_family_name").unwrap());
+        attrs.push(Nlattr::new(CtrlAttr::FamilyId, 5u32).unwrap());
+        attrs.push(Nlattr::new(CtrlAttr::FamilyName, "my_family_name").unwrap());
         let nl1 = Nlmsghdr::new(
             None,
             NlTypeWrapper::Nlmsg(Nlmsg::Noop),
@@ -868,8 +868,8 @@ mod test {
         );
 
         let mut attrs = GenlBuffer::new();
-        attrs.push(Nlattr::new(false, CtrlAttr::FamilyId, 6u32).unwrap());
-        attrs.push(Nlattr::new(false, CtrlAttr::FamilyName, "my_other_family_name").unwrap());
+        attrs.push(Nlattr::new(CtrlAttr::FamilyId, 6u32).unwrap());
+        attrs.push(Nlattr::new(CtrlAttr::FamilyName, "my_other_family_name").unwrap());
         let nl2 = Nlmsghdr::new(
             None,
             NlTypeWrapper::Nlmsg(Nlmsg::Noop),

--- a/src/types.rs
+++ b/src/types.rs
@@ -381,9 +381,9 @@ mod test {
     fn test_genlbuffer_align() {
         assert_eq!(
             vec![
-                Nlattr::new(false, Index::from(0), 0u8,).unwrap(),
-                Nlattr::new(false, Index::from(1), 1u8,).unwrap(),
-                Nlattr::new(false, Index::from(2), 2u8,).unwrap(),
+                Nlattr::new(Index::from(0), 0u8,).unwrap(),
+                Nlattr::new(Index::from(1), 1u8,).unwrap(),
+                Nlattr::new(Index::from(2), 2u8,).unwrap(),
             ]
             .into_iter()
             .collect::<GenlBuffer<Index, Buffer>>()


### PR DESCRIPTION
Most netlink protocols use native-endian; simplify the common case.
