### PR TITLE
Fix error field interpretation

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -76,7 +76,7 @@ pub struct Nlmsgerr<T, P> {
 
 impl<T, P> Display for Nlmsgerr<T, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", io::Error::from_raw_os_error(self.error))
+        write!(f, "{}", io::Error::from_raw_os_error(-self.error))
     }
 }
 


### PR DESCRIPTION
According to man 7 netlink, in case of error, the error field represents "negative errno". Also a simple test trying to add an interface as an unprivileged user, I get that field as -1 which the Display function translates into "Unknown error". With the change proposed, I get  "Operation not permitted" which is what one would expect.