### PR TITLE
Close netlink socket on execve

### DIFF
--- a/src/socket/shared.rs
+++ b/src/socket/shared.rs
@@ -21,12 +21,16 @@ impl NlSocket {
     /// Wrapper around `socket()` syscall filling in the
     /// netlink-specific information.
     pub fn new(proto: NlFamily) -> Result<Self, io::Error> {
-        let fd =
-            match unsafe { libc::socket(AddrFamily::Netlink.into(), libc::SOCK_RAW, proto.into()) }
-            {
-                i if i >= 0 => Ok(i),
-                _ => Err(io::Error::last_os_error()),
-            }?;
+        let fd = match unsafe {
+            libc::socket(
+                AddrFamily::Netlink.into(),
+                libc::SOCK_RAW | libc::SOCK_CLOEXEC,
+                proto.into(),
+            )
+        } {
+            i if i >= 0 => Ok(i),
+            _ => Err(io::Error::last_os_error()),
+        }?;
         Ok(NlSocket { fd })
     }
 


### PR DESCRIPTION
Set the option SOCK_CLOEXEC on the newly created netlink socket, so that it does not leak on concurrent execve(2) calls in a sibling thread.