### PR TITLE
Add methods to control strict input checking for route sockets

### DIFF
--- a/examples/getips.rs
+++ b/examples/getips.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     let (rtnl, _) = NlRouter::connect(NlFamily::Route, None, Groups::empty())?;
+    rtnl.enable_strict_checking(true)?;
     let ifaddrmsg = IfaddrmsgBuilder::default()
         .ifa_family(RtAddrFamily::Inet)
         .ifa_prefixlen(0)

--- a/src/router/asynchronous.rs
+++ b/src/router/asynchronous.rs
@@ -193,6 +193,16 @@ impl NlRouter {
             .map_err(RouterError::from)
     }
 
+    /// If [`true`] is passed in, enable strict checking for this socket. If [`false`]
+    /// is passed in, disable strict checking for for this socket.
+    /// Only supported by `NlFamily::Route` sockets.
+    /// Requires Linux >= 4.20.
+    pub fn enable_strict_checking(&self, enable: bool) -> Result<(), RouterError<u16, Buffer>> {
+        self.socket
+            .enable_strict_checking(enable)
+            .map_err(RouterError::from)
+    }
+
     /// Get the PID for the current socket.
     pub fn pid(&self) -> u32 {
         self.socket.pid()

--- a/src/router/synchronous.rs
+++ b/src/router/synchronous.rs
@@ -178,6 +178,16 @@ impl NlRouter {
             .map_err(RouterError::from)
     }
 
+    /// If [`true`] is passed in, enable strict checking for this socket. If [`false`]
+    /// is passed in, disable strict checking for for this socket.
+    /// Only supported by `NlFamily::Route` sockets.
+    /// Requires Linux >= 4.20.
+    pub fn enable_strict_checking(&self, enable: bool) -> Result<(), RouterError<u16, Buffer>> {
+        self.socket
+            .enable_strict_checking(enable)
+            .map_err(RouterError::from)
+    }
+
     /// Get the PID for the current socket.
     pub fn pid(&self) -> u32 {
         self.socket.pid()
@@ -506,6 +516,7 @@ mod test {
         setup();
 
         let (sock, _) = NlRouter::connect(NlFamily::Generic, None, Groups::empty()).unwrap();
+        sock.enable_strict_checking(true).unwrap();
         let notify_id_result = sock.resolve_nl_mcast_group("nlctrl", "notify");
         let config_id_result = sock.resolve_nl_mcast_group("devlink", "config");
 

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -471,6 +471,7 @@ mod test {
         setup();
 
         let (sock, _) = NlRouter::connect(NlFamily::Route, None, Groups::empty()).unwrap();
+        sock.enable_strict_checking(true).unwrap();
         let recv = sock
             .send::<_, _, Rtm, Ifinfomsg>(
                 Rtm::Getlink,
@@ -503,6 +504,7 @@ mod test {
         setup();
 
         let (sock, _) = NlRouter::connect(NlFamily::Route, None, Groups::empty()).unwrap();
+        sock.enable_strict_checking(true).unwrap();
         let recv = sock
             .send::<_, _, Rtm, Tcmsg>(
                 Rtm::Getqdisc,

--- a/src/socket/asynchronous.rs
+++ b/src/socket/asynchronous.rs
@@ -161,6 +161,17 @@ impl NlSocketHandle {
             .enable_ext_ack(enable)
             .map_err(SocketError::from)
     }
+
+    /// If [`true`] is passed in, enable strict checking for this socket. If [`false`]
+    /// is passed in, disable strict checking for for this socket.
+    /// Only supported by `NlFamily::Route` sockets.
+    /// Requires Linux >= 4.20.
+    pub fn enable_strict_checking(&self, enable: bool) -> Result<(), SocketError> {
+        self.socket
+            .get_ref()
+            .enable_strict_checking(enable)
+            .map_err(SocketError::from)
+    }
 }
 
 impl AsRawFd for NlSocketHandle {

--- a/src/socket/shared.rs
+++ b/src/socket/shared.rs
@@ -240,6 +240,25 @@ impl NlSocket {
             _ => Err(io::Error::last_os_error()),
         }
     }
+
+    /// If [`true`] is passed in, enable strict checking for this socket. If [`false`]
+    /// is passed in, disable strict checking for for this socket.
+    /// Only supported by `NlFamily::Route` sockets.
+    /// Requires Linux >= 4.20.
+    pub fn enable_strict_checking(&self, enable: bool) -> Result<(), io::Error> {
+        match unsafe {
+            libc::setsockopt(
+                self.fd,
+                libc::SOL_NETLINK,
+                libc::NETLINK_GET_STRICT_CHK,
+                &libc::c_int::from(enable) as *const _ as *const libc::c_void,
+                size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        } {
+            i if i == 0 => Ok(()),
+            _ => Err(io::Error::last_os_error()),
+        }
+    }
 }
 
 impl From<NlSocketHandle> for NlSocket {

--- a/src/socket/shared.rs
+++ b/src/socket/shared.rs
@@ -233,7 +233,7 @@ impl NlSocket {
                 libc::SOL_NETLINK,
                 libc::NETLINK_EXT_ACK,
                 &i32::from(enable) as *const _ as *const libc::c_void,
-                size_of::<u32>() as libc::socklen_t,
+                size_of::<i32>() as libc::socklen_t,
             )
         } {
             i if i == 0 => Ok(()),

--- a/src/socket/synchronous.rs
+++ b/src/socket/synchronous.rs
@@ -135,6 +135,16 @@ impl NlSocketHandle {
             .enable_ext_ack(enable)
             .map_err(SocketError::from)
     }
+
+    /// If [`true`] is passed in, enable strict checking for this socket. If [`false`]
+    /// is passed in, disable strict checking for for this socket.
+    /// Only supported by `NlFamily::Route` sockets.
+    /// Requires Linux >= 4.20.
+    pub fn enable_strict_checking(&self, enable: bool) -> Result<(), SocketError> {
+        self.socket
+            .enable_strict_checking(enable)
+            .map_err(SocketError::from)
+    }
 }
 
 impl AsRawFd for NlSocketHandle {


### PR DESCRIPTION
Supported since Linux 4.20.

See https://kernel.org/doc/html/next/userspace-api/netlink/intro.html#strict-checking