### PR TITLE
`get_nested_attributes` doesn't need `&mut self`

### DIFF
--- a/examples/neli.rs
+++ b/examples/neli.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Get parsing handler for the attributes in this message where the next call
     // to either get_nested_attributes() or get_payload() will expect a u16 type
     // to be provided
-    let mut handle = nlmsg
+    let handle = nlmsg
         .get_payload()
         .ok_or_else(|| MsgError::new("No payload found"))?
         .attrs()

--- a/src/genl.rs
+++ b/src/genl.rs
@@ -342,7 +342,7 @@ where
 {
     /// Get the payload of an attribute as a handle for parsing
     /// nested attributes
-    pub fn get_nested_attributes<S>(&mut self, subattr: T) -> Result<GenlAttrHandle<S>, DeError>
+    pub fn get_nested_attributes<S>(&self, subattr: T) -> Result<GenlAttrHandle<S>, DeError>
     where
         S: NlAttrType,
     {

--- a/src/router/asynchronous.rs
+++ b/src/router/asynchronous.rs
@@ -320,7 +320,7 @@ impl NlRouter {
         let nlhdrs = self.get_genl_family(family_name).await?;
         for nlhdr in nlhdrs {
             if let NlPayload::Payload(p) = nlhdr.nl_payload() {
-                let mut handle = p.attrs().get_attr_handle();
+                let handle = p.attrs().get_attr_handle();
                 let mcast_groups = handle.get_nested_attributes::<Index>(CtrlAttr::McastGroups)?;
                 if let Some(id) = mcast_groups.iter().find_map(|item| {
                     let nested_attrs = item.get_attr_handle::<CtrlAttrMcastGrp>().ok()?;
@@ -369,7 +369,7 @@ impl NlRouter {
             let msg = res_msg?;
 
             if let NlPayload::Payload(p) = msg.nl_payload() {
-                let mut attributes = p.attrs().get_attr_handle();
+                let attributes = p.attrs().get_attr_handle();
                 let name =
                     attributes.get_attr_payload_as_with_len::<String>(CtrlAttr::FamilyName)?;
                 let groups = match attributes.get_nested_attributes::<Index>(CtrlAttr::McastGroups)

--- a/src/router/synchronous.rs
+++ b/src/router/synchronous.rs
@@ -303,7 +303,7 @@ impl NlRouter {
         let nlhdrs = self.get_genl_family(family_name)?;
         for nlhdr in nlhdrs {
             if let NlPayload::Payload(p) = nlhdr.nl_payload() {
-                let mut handle = p.attrs().get_attr_handle();
+                let handle = p.attrs().get_attr_handle();
                 let mcast_groups = handle.get_nested_attributes::<Index>(CtrlAttr::McastGroups)?;
                 if let Some(id) = mcast_groups.iter().find_map(|item| {
                     let nested_attrs = item.get_attr_handle::<CtrlAttrMcastGrp>().ok()?;
@@ -350,7 +350,7 @@ impl NlRouter {
             let msg = res_msg?;
 
             if let NlPayload::Payload(p) = msg.nl_payload() {
-                let mut attributes = p.attrs().get_attr_handle();
+                let attributes = p.attrs().get_attr_handle();
                 let name =
                     attributes.get_attr_payload_as_with_len::<String>(CtrlAttr::FamilyName)?;
                 let groups = match attributes.get_nested_attributes::<Index>(CtrlAttr::McastGroups)

--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -366,7 +366,7 @@ where
 {
     /// Get the payload of an attribute as a handle for parsing
     /// nested attributes.
-    pub fn get_nested_attributes<S>(&mut self, subattr: T) -> Result<RtAttrHandle<S>, DeError>
+    pub fn get_nested_attributes<S>(&self, subattr: T) -> Result<RtAttrHandle<S>, DeError>
     where
         S: RtaType,
     {


### PR DESCRIPTION
While using this I noticed that the `.get_nested_attributes` took mutable references, but I don't think the `mut` is required here. 

This PR removes it (and _**targets the `v0.7.0-rc2` branch**_).

---

By the way, `v0.7.0-rc2` is looking really good IMO!