### PR TITLE
Update libc to version 0.2.168

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = "2.4"
 byteorder = "1.3"
 derive_builder = "0.11"
 getset = "0.1.2"
-libc = "0.2.105"
+libc = "0.2.168"
 log = "0.4"
 
 [dependencies.neli-proc-macros]

--- a/src/consts/rtnl.rs
+++ b/src/consts/rtnl.rs
@@ -349,7 +349,6 @@ pub enum Ifa {
     Anycast = libc::IFA_ANYCAST,
     Cacheinfo = libc::IFA_CACHEINFO,
     Multicast = libc::IFA_MULTICAST,
-    #[cfg(target_env = "gnu")]
     Flags = libc::IFA_FLAGS,
 }
 


### PR DESCRIPTION
Allows to lift `#[cfg(target_env = "gnu"]` from `Ifa::Flags` definition.