### PR TITLE
Update libc to version 0.2.168

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 
 [dependencies]
 byteorder = "1.3"
-libc = "0.2.82"
+libc = "0.2.168"
 log = "0.4"
 
 [dependencies.neli-proc-macros]

--- a/src/consts/rtnl.rs
+++ b/src/consts/rtnl.rs
@@ -241,7 +241,6 @@ pub enum Ifa {
     Anycast = libc::IFA_ANYCAST,
     Cacheinfo = libc::IFA_CACHEINFO,
     Multicast = libc::IFA_MULTICAST,
-    #[cfg(target_env = "gnu")]
     Flags = libc::IFA_FLAGS,
 }
 


### PR DESCRIPTION
Allows to lift `#[cfg(target_env = "gnu")]` from `Ifa::Flags` definition