### PR TITLE
Cargo.toml: Bump derive_builder dependency version to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 [dependencies]
 bitflags = "2.4"
 byteorder = "1.3"
-derive_builder = "0.11"
+derive_builder = "0.20"
 getset = "0.1.2"
 libc = "0.2.105"
 log = "0.4"


### PR DESCRIPTION
Debian packages 0.20.1, Fedora packages 0.20.2, which makes impractical to stick to 0.11. I did some quick tests and everything seems to work with 0.20.