### PR TITLE
rtnl: Pass native-endian values to Rtattr::from_bytes in tests

### DIFF
--- a/src/rtnl.rs
+++ b/src/rtnl.rs
@@ -441,7 +441,7 @@ mod test {
     fn test_rta_deserialize() {
         setup();
 
-        let buf = &[4u8, 0, 0, 0] as &[u8];
+        let buf = &4u32.to_ne_bytes() as &[u8];
         Rtattr::<Rta, Buffer>::from_bytes(&mut Cursor::new(buf)).unwrap();
     }
 
@@ -450,7 +450,7 @@ mod test {
         setup();
 
         // 3 bytes is below minimum length
-        let buf = &[3u8, 0, 0, 0] as &[u8];
+        let buf = &3u32.to_ne_bytes() as &[u8];
         Rtattr::<Rta, Buffer>::from_bytes(&mut Cursor::new(buf)).unwrap_err();
     }
 


### PR DESCRIPTION
Provided by Kitlith <kitlith@kitl.pw> on:

  https://github.com/jbaublitz/neli/issues/273

...if we build input buffers for Rtattr::from_bytes byte-by-byte in the test_rta_deserialize and test_rta_deserialize_err tests, they will fail unless we adapt to the current endianness. Specifically, the existing version would fail on big-endian machines.

Given that Rtattr::from_bytes is supposed to take native-endian values, build values accordingly.

Link: https://github.com/jbaublitz/neli/issues/273
Analysed-by: Fabio Valentini <decathorpe@gmail.com>
Analysed-by: Kitlith <kitlith@kitl.pw>