### PR TITLE
fix: log naked structs at trace!() level

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -2,7 +2,7 @@
 
 use std::{io::Cursor, marker::PhantomData};
 
-use log::debug;
+use log::trace;
 
 use crate::{
     consts::nl::NlType, err::SocketError, nl::Nlmsghdr, FromBytes, FromBytesWithInput, Size,
@@ -43,7 +43,7 @@ where
         } else {
             match Nlmsghdr::from_bytes(&mut self.buffer).map_err(SocketError::from) {
                 Ok(msg) => {
-                    debug!("Message received: {:?}", msg);
+                    trace!("Message received: {:?}", msg);
                     Some(Ok(msg))
                 }
                 Err(e) => {

--- a/src/router/asynchronous.rs
+++ b/src/router/asynchronous.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-use log::{debug, error, trace, warn};
+use log::{error, trace, warn};
 use tokio::{
     spawn,
     sync::{
@@ -501,7 +501,7 @@ where
             return Some(Err(RouterError::NoAck));
         }
 
-        debug!("Router received message: {:?}", msg);
+        trace!("Router received message: {:?}", msg);
 
         Some(Ok(msg))
     }

--- a/src/router/synchronous.rs
+++ b/src/router/synchronous.rs
@@ -9,7 +9,7 @@ use std::{
     thread::spawn,
 };
 
-use log::{debug, error, trace, warn};
+use log::{error, trace, warn};
 use parking_lot::Mutex;
 
 use crate::{
@@ -493,7 +493,7 @@ where
             return Some(Err(RouterError::NoAck));
         }
 
-        debug!("Router received message: {:?}", msg);
+        trace!("Router received message: {:?}", msg);
 
         Some(Ok(msg))
     }

--- a/src/socket/asynchronous.rs
+++ b/src/socket/asynchronous.rs
@@ -4,7 +4,7 @@ use std::{
     os::unix::io::{AsRawFd, IntoRawFd, RawFd},
 };
 
-use log::{debug, trace};
+use log::trace;
 use tokio::io::unix::AsyncFd;
 
 use crate::{
@@ -154,7 +154,7 @@ impl NlSocketHandle {
 
         let vec = NlBuffer::from_bytes_with_input(&mut Cursor::new(buffer), bytes_read)?;
 
-        debug!("Messages received: {:?}", vec);
+        trace!("Messages received: {:?}", vec);
 
         Ok((vec, groups))
     }

--- a/src/socket/synchronous.rs
+++ b/src/socket/synchronous.rs
@@ -4,7 +4,7 @@ use std::{
     os::unix::io::{AsRawFd, IntoRawFd, RawFd},
 };
 
-use log::{debug, trace};
+use log::trace;
 
 use crate::{
     consts::{nl::*, socket::*},
@@ -72,7 +72,7 @@ impl NlSocketHandle {
         T: NlType + Debug,
         P: Size + ToBytes + Debug,
     {
-        debug!("Message sent:\n{:?}", msg);
+        trace!("Message sent:\n{:?}", msg);
 
         let mut buffer = Cursor::new(vec![0; msg.padded_size()]);
         msg.to_bytes(&mut buffer)?;
@@ -126,7 +126,7 @@ impl NlSocketHandle {
 
         let vec = NlBuffer::from_bytes_with_input(&mut Cursor::new(buffer), mem_read)?;
 
-        debug!("Messages received: {:?}", vec);
+        trace!("Messages received: {:?}", vec);
 
         Ok((vec, groups))
     }


### PR DESCRIPTION
The problem with logging at debug level is that we have neli as part of a much bigger binary, and right now neli dumps very big unformatted structs in syslog.

We believe that neli should instead log these items at a lower level, such as trace!(). Debug-level log messages are still relevant for end users of the system, but trace messages are only for developers that know their way around on the system and thus are expected to know how to filter noise out (e.g. via environment variables to the logger).