### PR TITLE
Feature/connector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = "2.4"
 byteorder = "1.3"
 derive_builder = "0.20"
 getset = "0.1.2"
-libc = "0.2.172"
+libc = "0.2.174"
 log = "0.4"
 
 [dependencies.neli-proc-macros]

--- a/examples/procmon.rs
+++ b/examples/procmon.rs
@@ -1,0 +1,87 @@
+//! A small process monitor example using netlink connector messages.
+//!
+//! You must run this example with root privileges, in the root pid namespace
+//!
+//! See this blog post for more details:
+//! https://nick-black.com/dankwiki/index.php/The_Proc_Connector_and_Socket_Filters
+
+use neli::{
+    connector::{CnMsg, ProcEvent, ProcEventHeader},
+    consts::{
+        connector::{CnMsgIdx, CnMsgVal, ProcCnMcastOp},
+        nl::{NlmF, Nlmsg},
+        socket::NlFamily,
+    },
+    nl::{NlPayload, NlmsghdrBuilder},
+    socket::synchronous::NlSocketHandle,
+    utils::Groups,
+};
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let pid = std::process::id();
+    let socket = NlSocketHandle::connect(
+        NlFamily::Connector,
+        Some(pid),
+        Groups::new_bitmask(CnMsgIdx::Proc.into()),
+    )?;
+
+    let subscribe = NlmsghdrBuilder::default()
+        .nl_type(Nlmsg::Done)
+        .nl_flags(NlmF::empty())
+        .nl_pid(pid)
+        .nl_payload(NlPayload::Payload(
+            neli::connector::CnMsgBuilder::default()
+                .idx(CnMsgIdx::Proc)
+                .val(CnMsgVal::Proc)
+                .payload(ProcCnMcastOp::Listen)
+                .build()?,
+        ))
+        .build()?;
+
+    socket.send(&subscribe)?;
+
+    loop {
+        for event in socket.recv::<Nlmsg, CnMsg<ProcEventHeader>>()?.0 {
+            let ProcEvent::Exec { process_pid, .. } = event?
+                .get_payload()
+                .ok_or("Failed to extract payload")?
+                .payload()
+                .event
+            else {
+                continue;
+            };
+
+            let exe = fs::read_link(format!("/proc/{}/exe", process_pid))
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "unknown".to_string());
+            let cmdline = cmdline_to_string(process_pid).unwrap_or_else(|_| "unknown".to_string());
+            println!(
+                "Process created: PID: {}, Exe: {}, Cmdline: {}",
+                process_pid, exe, cmdline
+            );
+        }
+    }
+}
+
+fn cmdline_to_string(pid: i32) -> std::io::Result<String> {
+    // 1) Read the entire file into a byte‐buffer in one go
+    let mut data = fs::read(format!("/proc/{pid}/cmdline"))?;
+
+    // 2) In‐place map all remaining NULs to spaces
+    for b in &mut data {
+        if *b == 0 {
+            *b = b' ';
+        }
+    }
+
+    // 3) SAFELY convert bytes → String without re‐checking UTF‐8
+    //
+    //    We can do this because /proc/cmdline is guaranteed to be valid UTF-8
+    //    on Linux (arguments must be passed as UTF-8), so we skip the cost
+    //    of a UTF-8 validation pass.
+    let s = unsafe { String::from_utf8_unchecked(data) };
+    Ok(s)
+}

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,0 +1,340 @@
+//! Connector module for Linux Netlink connector messages.
+//!
+//! This module provides support for the Linux Netlink connector subsystem,
+//! which creates a communication channel between userspace programs and the kernel.
+//! It allows applications to receive notifications about various kernel events.
+//!
+//! This module currently provides full support for the Linux proc connector protocol,
+//! enabling the reception and handling of process lifecycle events such as creation,
+//! termination, exec, UID/GID/sid changes, tracing, name changes, and core dumps.
+//!
+//! ## Supported protocols
+//! At this time, only the proc connector (`PROC_CN`) protocol is fully implemented.
+//!
+//! ## Extensibility
+//! The implementation can be extended in two ways:
+//! 1. By defining additional types and logic in your own crate and using them with this module.
+//! 2. By using a `Vec<u8>` as a payload and manually parsing protocol messages to suit other connector protocols.
+//!
+//! This design allows both high-level ergonomic handling of proc events and low-level manual parsing for custom needs.
+use crate::{
+    self as neli,
+    consts::connector::{CnMsgIdx, CnMsgVal, ProcEventType},
+    err::{DeError, MsgError},
+    FromBytesWithInput, Header, Size, ToBytes,
+};
+use byteorder::{NativeEndian, ReadBytesExt};
+use derive_builder::Builder;
+use getset::Getters;
+use log::trace;
+use std::{io::Cursor, io::Read};
+
+/// Netlink connector message header and payload.
+#[derive(
+    Builder, Getters, Clone, Debug, PartialEq, Eq, Size, ToBytes, FromBytesWithInput, Header,
+)]
+#[neli(from_bytes_bound = "P: Size + FromBytesWithInput<Input = usize>")]
+#[builder(pattern = "owned")]
+pub struct CnMsg<P: Size> {
+    /// Index of the connector (idx)
+    #[getset(get = "pub")]
+    idx: CnMsgIdx,
+    /// Value (val)
+    #[getset(get = "pub")]
+    val: CnMsgVal,
+    /// Sequence number
+    #[builder(default)]
+    #[getset(get = "pub")]
+    seq: u32,
+    /// Acknowledgement number
+    #[builder(default)]
+    #[getset(get = "pub")]
+    ack: u32,
+    /// Length of the payload
+    #[builder(
+        setter(skip),
+        default = "self.payload.as_ref().unwrap().unpadded_size() as _"
+    )]
+    #[getset(get = "pub")]
+    len: u16,
+    /// Flags
+    #[builder(default)]
+    #[getset(get = "pub")]
+    flags: u16,
+    /// Payload of the netlink message
+    ///
+    /// You can either use predefined types like `ProcCnMcastOp` or `ProcEventHeader`,
+    /// a custom type defined by you or `Vec<u8>` for raw payload.
+    #[neli(size = "len as usize")]
+    #[neli(input = "(len as usize)")]
+    #[getset(get = "pub")]
+    pub(crate) payload: P,
+}
+
+// -- proc connector structs --
+
+/// Header for process event messages.
+#[derive(Debug, Size)]
+pub struct ProcEventHeader {
+    /// The CPU on which the event occurred.
+    pub cpu: u32,
+    /// Nanosecond timestamp of the event.
+    pub timestamp_ns: u64,
+    /// The process event data.
+    pub event: ProcEvent,
+}
+
+/// Ergonomic enum for process event data.
+#[derive(Debug, Size, Copy, Clone)]
+pub enum ProcEvent {
+    /// Acknowledgement event, typically for PROC_EVENT_NONE.
+    Ack {
+        /// Error code (0 for success).
+        err: u32,
+    },
+    /// Fork event, triggered when a process forks.
+    Fork {
+        /// Parent process PID.
+        parent_pid: i32,
+        /// Parent process TGID (thread group ID).
+        parent_tgid: i32,
+        /// Child process PID.
+        child_pid: i32,
+        /// Child process TGID.
+        child_tgid: i32,
+    },
+    /// Exec event, triggered when a process calls exec().
+    Exec {
+        /// Process PID.
+        process_pid: i32,
+        /// Process TGID.
+        process_tgid: i32,
+    },
+    /// UID change event, triggered when a process changes its UID.
+    Uid {
+        /// Process PID.
+        process_pid: i32,
+        /// Process TGID.
+        process_tgid: i32,
+        /// Real UID.
+        ruid: u32,
+        /// Effective UID.
+        euid: u32,
+    },
+    /// GID change event, triggered when a process changes its GID.
+    Gid {
+        /// Process PID.
+        process_pid: i32,
+        /// Process TGID.
+        process_tgid: i32,
+        /// Real GID.
+        rgid: u32,
+        /// Effective GID.
+        egid: u32,
+    },
+    /// SID change event, triggered when a process changes its session ID.
+    Sid {
+        /// Process PID.
+        process_pid: i32,
+        /// Process TGID.
+        process_tgid: i32,
+    },
+    /// Ptrace event, triggered when a process is traced.
+    Ptrace {
+        /// Process PID.
+        process_pid: i32,
+        /// Process TGID.
+        process_tgid: i32,
+        /// Tracer process PID.
+        tracer_pid: i32,
+        /// Tracer process TGID.
+        tracer_tgid: i32,
+    },
+    /// Comm event, triggered when a process changes its command name.
+    Comm {
+        /// Process PID.
+        process_pid: i32,
+        /// Process TGID.
+        process_tgid: i32,
+        /// Command name (null-terminated, max 16 bytes).
+        comm: [u8; 16],
+    },
+    /// Coredump event, triggered when a process dumps core.
+    Coredump {
+        /// Process PID.
+        process_pid: i32,
+        /// Process TGID.
+        process_tgid: i32,
+        /// Parent process PID.
+        parent_pid: i32,
+        /// Parent process TGID.
+        parent_tgid: i32,
+    },
+    /// Exit event, triggered when a process exits.
+    Exit {
+        /// Process PID.
+        process_pid: i32,
+        /// Process TGID.
+        process_tgid: i32,
+        /// Exit code.
+        exit_code: u32,
+        /// Exit signal.
+        exit_signal: u32,
+        /// Parent process PID.
+        parent_pid: i32,
+        /// Parent process TGID.
+        parent_tgid: i32,
+    },
+}
+
+impl FromBytesWithInput for ProcEventHeader {
+    type Input = usize;
+
+    fn from_bytes_with_input(
+        buffer: &mut Cursor<impl AsRef<[u8]>>,
+        input: Self::Input,
+    ) -> Result<Self, DeError> {
+        let start = buffer.position() as usize;
+        let bytes = buffer.get_ref().as_ref();
+
+        trace!(
+            "Parsing ProcEventHeader at position {} with input size {}",
+            start,
+            input
+        );
+
+        // Minimum size for header (16) + smallest event (ack: 4) is 20.
+        if input < 16 || bytes.len() < start + input {
+            return Err(DeError::InvalidInput(input));
+        }
+
+        // Read header fields: what (u32), cpu (u32), timestamp_ns (u64)
+        let what_val = buffer.read_u32::<NativeEndian>()?;
+        let what = ProcEventType::from(what_val);
+        let cpu = buffer.read_u32::<NativeEndian>()?;
+        let timestamp_ns = buffer.read_u64::<NativeEndian>()?;
+
+        let event = match what {
+            ProcEventType::None => ProcEvent::Ack {
+                err: buffer.read_u32::<NativeEndian>()?,
+            },
+            ProcEventType::Fork => ProcEvent::Fork {
+                parent_pid: buffer.read_i32::<NativeEndian>()?,
+                parent_tgid: buffer.read_i32::<NativeEndian>()?,
+                child_pid: buffer.read_i32::<NativeEndian>()?,
+                child_tgid: buffer.read_i32::<NativeEndian>()?,
+            },
+            ProcEventType::Exec => ProcEvent::Exec {
+                process_pid: buffer.read_i32::<NativeEndian>()?,
+                process_tgid: buffer.read_i32::<NativeEndian>()?,
+            },
+            ProcEventType::Uid => ProcEvent::Uid {
+                process_pid: buffer.read_i32::<NativeEndian>()?,
+                process_tgid: buffer.read_i32::<NativeEndian>()?,
+                ruid: buffer.read_u32::<NativeEndian>()?,
+                euid: buffer.read_u32::<NativeEndian>()?,
+            },
+            ProcEventType::Gid => ProcEvent::Gid {
+                process_pid: buffer.read_i32::<NativeEndian>()?,
+                process_tgid: buffer.read_i32::<NativeEndian>()?,
+                rgid: buffer.read_u32::<NativeEndian>()?,
+                egid: buffer.read_u32::<NativeEndian>()?,
+            },
+            ProcEventType::Sid => ProcEvent::Sid {
+                process_pid: buffer.read_i32::<NativeEndian>()?,
+                process_tgid: buffer.read_i32::<NativeEndian>()?,
+            },
+            ProcEventType::Ptrace => ProcEvent::Ptrace {
+                process_pid: buffer.read_i32::<NativeEndian>()?,
+                process_tgid: buffer.read_i32::<NativeEndian>()?,
+                tracer_pid: buffer.read_i32::<NativeEndian>()?,
+                tracer_tgid: buffer.read_i32::<NativeEndian>()?,
+            },
+            ProcEventType::Comm => {
+                let process_pid = buffer.read_i32::<NativeEndian>()?;
+                let process_tgid = buffer.read_i32::<NativeEndian>()?;
+                let mut comm = [0u8; 16];
+                buffer.read_exact(&mut comm)?;
+                ProcEvent::Comm {
+                    process_pid,
+                    process_tgid,
+                    comm,
+                }
+            }
+            ProcEventType::Coredump => ProcEvent::Coredump {
+                process_pid: buffer.read_i32::<NativeEndian>()?,
+                process_tgid: buffer.read_i32::<NativeEndian>()?,
+                parent_pid: buffer.read_i32::<NativeEndian>()?,
+                parent_tgid: buffer.read_i32::<NativeEndian>()?,
+            },
+            ProcEventType::Exit | ProcEventType::NonzeroExit => ProcEvent::Exit {
+                process_pid: buffer.read_i32::<NativeEndian>()?,
+                process_tgid: buffer.read_i32::<NativeEndian>()?,
+                exit_code: buffer.read_u32::<NativeEndian>()?,
+                exit_signal: buffer.read_u32::<NativeEndian>()?,
+                parent_pid: buffer.read_i32::<NativeEndian>()?,
+                parent_tgid: buffer.read_i32::<NativeEndian>()?,
+            },
+            ProcEventType::UnrecognizedConst(i) => {
+                return Err(DeError::Msg(MsgError::new(format!(
+                    "Unrecognized Proc event type: {i} (raw value: {what_val})"
+                ))));
+            }
+        };
+
+        // consume the entire len, because the kernel can pad the event data with zeros
+        buffer.set_position(start as u64 + input as u64);
+
+        Ok(ProcEventHeader {
+            cpu,
+            timestamp_ns,
+            event,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static RAW_RESPONSE: &[u8] = &[
+        1, 0, 0, 0, 1, 0, 0, 0, 122, 2, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 184,
+        52, 84, 25, 71, 2, 0, 0, 127, 22, 0, 0, 127, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0,
+    ];
+
+    #[test]
+    fn parse_static_proc_header() {
+        let mut cursor = Cursor::new(&RAW_RESPONSE);
+
+        let msg: CnMsg<ProcEventHeader> =
+            CnMsg::from_bytes_with_input(&mut cursor, RAW_RESPONSE.len()).unwrap();
+
+        assert_eq!(msg.idx(), &CnMsgIdx::Proc);
+        assert_eq!(msg.val(), &CnMsgVal::Proc);
+        assert_eq!(msg.payload.cpu, 1);
+        assert_eq!(msg.payload.timestamp_ns, 2504390882488);
+        match &msg.payload.event {
+            ProcEvent::Exec {
+                process_pid,
+                process_tgid,
+            } => {
+                assert_eq!(*process_pid, 5759);
+                assert_eq!(*process_tgid, 5759);
+            }
+            _ => panic!("Expected Exec event"),
+        }
+    }
+
+    #[test]
+    fn parse_static_raw_data() {
+        let mut cursor = Cursor::new(&RAW_RESPONSE);
+
+        let msg: CnMsg<Vec<u8>> =
+            CnMsg::from_bytes_with_input(&mut cursor, RAW_RESPONSE.len()).unwrap();
+
+        assert_eq!(msg.idx(), &CnMsgIdx::Proc);
+        assert_eq!(msg.val(), &CnMsgVal::Proc);
+        assert_eq!(msg.payload, RAW_RESPONSE[CnMsg::<Vec<u8>>::header_size()..]);
+    }
+}

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -18,10 +18,9 @@
 //!
 //! This design allows both high-level ergonomic handling of proc events and low-level manual parsing for custom needs.
 use crate::{
-    self as neli,
+    self as neli, FromBytesWithInput, Header, Size, ToBytes,
     consts::connector::{CnMsgIdx, CnMsgVal, ProcEventType},
     err::{DeError, MsgError},
-    FromBytesWithInput, Header, Size, ToBytes,
 };
 use byteorder::{NativeEndian, ReadBytesExt};
 use derive_builder::Builder;
@@ -197,11 +196,7 @@ impl FromBytesWithInput for ProcEventHeader {
         let start = buffer.position() as usize;
         let bytes = buffer.get_ref().as_ref();
 
-        trace!(
-            "Parsing ProcEventHeader at position {} with input size {}",
-            start,
-            input
-        );
+        trace!("Parsing ProcEventHeader at position {start} with input size {input}");
 
         // Minimum size for header (16) + smallest event (ack: 4) is 20.
         if input < 16 || bytes.len() < start + input {

--- a/src/consts/connector.rs
+++ b/src/consts/connector.rs
@@ -1,0 +1,53 @@
+use crate as neli;
+
+/// Values for `idx` in [`CnMsg`][crate::connector::CnMsg].
+#[neli::neli_enum(serialized_type = "u32")]
+pub enum CnMsgIdx {
+    Proc = libc::CN_IDX_PROC,
+    Cifs = libc::CN_IDX_CIFS,
+    W1 = libc::CN_W1_IDX,
+    V86d = libc::CN_IDX_V86D,
+    Bb = libc::CN_IDX_BB,
+    Dst = libc::CN_DST_IDX,
+    Dm = libc::CN_IDX_DM,
+    Drbd = libc::CN_IDX_DRBD,
+    Kvp = libc::CN_KVP_IDX,
+    Vss = libc::CN_VSS_IDX,
+}
+
+/// Values for `val` in [`CnMsg`][crate::connector::CnMsg].
+#[neli::neli_enum(serialized_type = "u32")]
+pub enum CnMsgVal {
+    Proc = libc::CN_VAL_PROC,
+    Cifs = libc::CN_VAL_CIFS,
+    W1 = libc::CN_W1_VAL,
+    V86dUvesafb = libc::CN_VAL_V86D_UVESAFB,
+    Dst = libc::CN_DST_VAL,
+    DmUserspaceLog = libc::CN_VAL_DM_USERSPACE_LOG,
+    Drbd = libc::CN_VAL_DRBD,
+    Kvp = libc::CN_KVP_VAL,
+    Vss = libc::CN_VSS_VAL,
+}
+
+/// Process event type as reported by the kernel connector.
+#[neli::neli_enum(serialized_type = "u32")]
+pub enum ProcEventType {
+    None = libc::PROC_EVENT_NONE,
+    Fork = libc::PROC_EVENT_FORK,
+    Exec = libc::PROC_EVENT_EXEC,
+    Uid = libc::PROC_EVENT_UID,
+    Gid = libc::PROC_EVENT_GID,
+    Sid = libc::PROC_EVENT_SID,
+    Ptrace = libc::PROC_EVENT_PTRACE,
+    Comm = libc::PROC_EVENT_COMM,
+    NonzeroExit = libc::PROC_EVENT_NONZERO_EXIT,
+    Coredump = libc::PROC_EVENT_COREDUMP,
+    Exit = libc::PROC_EVENT_EXIT,
+}
+
+/// Process event operations.
+#[neli::neli_enum(serialized_type = "u32")]
+pub enum ProcCnMcastOp {
+    Listen = libc::PROC_CN_MCAST_LISTEN,
+    Ignore = libc::PROC_CN_MCAST_IGNORE,
+}

--- a/src/consts/mod.rs
+++ b/src/consts/mod.rs
@@ -47,6 +47,8 @@
 #[macro_use]
 mod macros;
 
+/// Constants related to netlink connector interface
+pub mod connector;
 /// Constants related to generic netlink
 pub mod genl;
 /// Constants related to netfilter netlink integration

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -43,7 +43,7 @@ where
         } else {
             match Nlmsghdr::from_bytes(&mut self.buffer).map_err(SocketError::from) {
                 Ok(msg) => {
-                    trace!("Message received: {:?}", msg);
+                    trace!("Message received: {msg:?}");
                     Some(Ok(msg))
                 }
                 Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@
 #![deny(missing_docs)]
 
 pub mod attr;
+pub mod connector;
 pub mod consts;
 pub mod err;
 pub mod genl;
@@ -170,7 +171,7 @@ pub trait Size {
     /// strings or byte buffers.
     fn unpadded_size(&self) -> usize;
 
-    /// Get the size of of the payload and align it to
+    /// Get the size of the payload and align it to
     /// the required netlink byte alignment.
     fn padded_size(&self) -> usize {
         alignto(self.unpadded_size())
@@ -444,6 +445,12 @@ impl FromBytesWithInput for String {
 impl Size for &'_ [u8] {
     fn unpadded_size(&self) -> usize {
         self.len()
+    }
+}
+
+impl<const N: usize> Size for [u8; N] {
+    fn unpadded_size(&self) -> usize {
+        N
     }
 }
 

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -13,7 +13,6 @@
 //! application-level error handling.
 
 use std::{
-    any::type_name,
     io::Cursor,
     mem::{size_of, swap},
 };
@@ -61,7 +60,7 @@ where
         let pos = buffer.position();
 
         let mut processing = || {
-            trace!("Deserializing data type {}", type_name::<Self>());
+            trace!("Deserializing data type {}", std::any::type_name::<Self>());
             let ty_const: u16 = input_type.into();
             if ty_const == Nlmsg::Done.into() {
                 if buffer.position() == buffer.get_ref().as_ref().len() as u64 {

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -70,7 +70,7 @@ where
                         "Deserializing field type {}",
                         std::any::type_name::<Nlmsgerr<()>>(),
                     );
-                    trace!("Input: {:?}", input_size);
+                    trace!("Input: {input_size:?}");
                     let ext = Nlmsgerr::from_bytes_with_input(buffer, input_size)?;
                     Ok(NlPayload::DumpExtAck(ext))
                 } else {
@@ -86,15 +86,15 @@ where
                     std::any::type_name::<libc::c_int>()
                 );
                 let code = libc::c_int::from_bytes(buffer)?;
-                trace!("Field deserialized: {:?}", code);
+                trace!("Field deserialized: {code:?}");
                 if code == 0 {
                     trace!(
                         "Deserializing field type {}",
                         std::any::type_name::<NlmsghdrErr<T, ()>>()
                     );
-                    trace!("Input: {:?}", input_size);
+                    trace!("Input: {input_size:?}");
                     let nlmsg = NlmsghdrAck::<T>::from_bytes(buffer)?;
-                    trace!("Field deserialized: {:?}", nlmsg);
+                    trace!("Field deserialized: {nlmsg:?}");
                     Ok(NlPayload::Ack(
                         NlmsgerrBuilder::default().nlmsg(nlmsg).build()?,
                     ))
@@ -104,16 +104,16 @@ where
                         std::any::type_name::<NlmsghdrErr<T, ()>>()
                     );
                     let nlmsg = NlmsghdrErr::<T, P>::from_bytes(buffer)?;
-                    trace!("Field deserialized: {:?}", nlmsg);
+                    trace!("Field deserialized: {nlmsg:?}");
 
                     trace!(
                         "Deserializing field type {}",
                         std::any::type_name::<GenlBuffer<u16, Buffer>>()
                     );
                     let input = input_size - size_of::<libc::c_int>() - nlmsg.padded_size();
-                    trace!("Input: {:?}", input);
+                    trace!("Input: {input:?}");
                     let ext_ack = GenlBuffer::from_bytes_with_input(buffer, input)?;
-                    trace!("Field deserialized: {:?}", ext_ack);
+                    trace!("Field deserialized: {ext_ack:?}");
 
                     Ok(NlPayload::Err(
                         NlmsgerrBuilder::default()

--- a/src/router/synchronous.rs
+++ b/src/router/synchronous.rs
@@ -62,7 +62,7 @@ fn spawn_processing_thread(socket: Arc<NlSocketHandle>, senders: Senders) -> Pro
             match socket.recv::<u16, Buffer>() {
                 Ok((iter, group)) => {
                     for msg in iter {
-                        trace!("Message received: {:?}", msg);
+                        trace!("Message received: {msg:?}");
                         let mut seqs_to_remove = HashSet::new();
                         match msg {
                             Ok(m) => {
@@ -507,7 +507,7 @@ where
             return Some(Err(RouterError::NoAck));
         }
 
-        trace!("Router received message: {:?}", msg);
+        trace!("Router received message: {msg:?}");
 
         Some(Ok(msg))
     }

--- a/src/socket/synchronous.rs
+++ b/src/socket/synchronous.rs
@@ -72,7 +72,7 @@ impl NlSocketHandle {
         T: NlType + Debug,
         P: Size + ToBytes + Debug,
     {
-        trace!("Message sent:\n{:?}", msg);
+        trace!("Message sent:\n{msg:?}");
 
         let mut buffer = Cursor::new(vec![0; msg.padded_size()]);
         msg.to_bytes(&mut buffer)?;
@@ -126,7 +126,7 @@ impl NlSocketHandle {
 
         let vec = NlBuffer::from_bytes_with_input(&mut Cursor::new(buffer), mem_read)?;
 
-        trace!("Messages received: {:?}", vec);
+        trace!("Messages received: {vec:?}");
 
         Ok((vec, groups))
     }


### PR DESCRIPTION
Close #275 

So, a very early stage of the PR, but a working connector.

A few things to notice:

1. I commented the payload parsing because currently I use the `Nlmsghdr` to get the response from the socket, but with the connector protocol, a valid response comes with `nl_type` of Done, so the Payload parsed it as an error
2. In CnMsg, I flatten the struct `cb_id` from the kernel, but I don't really know if I should do it or not 

```c
struct cb_id {
	__u32 idx;
	__u32 val;
};

struct cn_msg {
	struct cb_id id;

	__u32 seq;
	__u32 ack;

	__u16 len;		/* Length of the following data */
	__u16 flags;
	__u8 data[];
};
```

To:

```rust
#[derive(
    Builder, Getters, Clone, Debug, PartialEq, Eq, Size, ToBytes, FromBytesWithInput, Header,
)]
#[neli(from_bytes_bound = "P: Size + FromBytesWithInput<Input = usize>")]
#[builder(build_fn(skip))]
#[builder(pattern = "owned")]
pub struct CnMsg<P> {
    /// Index of the connector (idx)
    #[getset(get = "pub")]
    idx: u32,
    /// Value (val)
    #[getset(get = "pub")]
    val: u32,
    /// Sequence number
    #[getset(get = "pub")]
    seq: u32,
    /// Acknowledgement number
    #[getset(get = "pub")]
    ack: u32,
    /// Length of the payload
    #[builder(setter(skip))]
    #[getset(get = "pub")]
    len: u16,
    /// Flags
    #[getset(get = "pub")]
    flags: u16,
    /// Payload of netlink message
    #[neli(size = "len as usize")]
    #[neli(input = "(len as usize)")]
    #[getset(get = "pub")]
    pub(crate) payload: P,
}
```
3. Currently I only support ProcEvents from the connector, but it can actually have different payloads, based on the idx and val. 
4. I need to check that idx and val are correct, otherwise I need to return an error
5. I don't really know if the parsing of the response is good enough or should be refactored, but from what I can understand, it cannot be automatically derived (the C code contains a number + union (instead of a more idiomatic enum in rust)
6. I still need to define al the consts, but I will do it after the PR in libc lands (https://github.com/rust-lang/libc/pull/4434)
7. Better docs + example