### PR TITLE
Pass full io::Error to user

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -21,6 +21,7 @@ use std::{
     io::{self, Cursor, ErrorKind},
     str::Utf8Error,
     string::FromUtf8Error,
+    sync::Arc,
 };
 
 use derive_builder::{Builder, UninitializedFieldError};
@@ -495,7 +496,7 @@ pub enum SocketError {
     /// A deserialization error.
     De(DeError),
     /// IO error.
-    Io(ErrorKind),
+    Io(Arc<io::Error>),
 }
 
 impl From<SerError> for SocketError {
@@ -512,7 +513,7 @@ impl From<DeError> for SocketError {
 
 impl From<io::Error> for SocketError {
     fn from(err: io::Error) -> Self {
-        SocketError::Io(err.kind())
+        SocketError::Io(Arc::new(err))
     }
 }
 


### PR DESCRIPTION
Currently, for io::Error only the error kind is returned to the user. This is a lossy conversion and may leave the user with a Uncategorized error and no way to debug this further.

As io::Error is not cloneable, wrap it in an Arc.

---

I'm not sure if there was an deliberate decision behin only keeping the ErrorKind other than io::Error not being Cloneable. This is a user facing API change, but I hope this is okay in an rc.

In my case I've got a Uncategorized error in `recv` which was actually a `ENOBUFS`. This error means that I'm not reading from the netlink socket fast enough. Without this patch there is no way I would have diagnosed the problem, so I hope the API-Change is acceptable.