### PR TITLE
Add option to set recv buffer size

### DIFF
--- a/src/socket/asynchronous.rs
+++ b/src/socket/asynchronous.rs
@@ -159,6 +159,26 @@ impl NlSocketHandle {
         Ok((vec, groups))
     }
 
+    /// Set the size of the receive buffer for the socket.
+    ///
+    /// This can be useful when communicating with a service that sends a high volume of
+    /// messages (especially multicast), and your application cannot process them fast enough,
+    /// leading to the kernel dropping messages. A larger buffer may help mitigate this.
+    ///
+    /// The value passed is a hint to the kernel to set the size of the receive buffer.
+    /// The kernel will double the value provided to account for bookkeeping overhead.
+    /// The doubled value is capped by the value in `/proc/sys/net/core/rmem_max`.
+    ///
+    /// The default value is `/proc/sys/net/core/rmem_default`
+    ///
+    /// See `socket(7)` documentation for `SO_RCVBUF` for more information.
+    pub fn set_recv_buffer_size(&self, size: usize) -> Result<(), SocketError> {
+        self.socket
+            .get_ref()
+            .set_recv_buffer_size(size)
+            .map_err(SocketError::from)
+    }
+
     /// If [`true`] is passed in, enable extended ACKs for this socket. If [`false`]
     /// is passed in, disable extended ACKs for this socket.
     pub fn enable_ext_ack(&self, enable: bool) -> Result<(), SocketError> {

--- a/src/socket/synchronous.rs
+++ b/src/socket/synchronous.rs
@@ -131,6 +131,25 @@ impl NlSocketHandle {
         Ok((vec, groups))
     }
 
+    /// Set the size of the receive buffer for the socket.
+    ///
+    /// This can be useful when communicating with a service that sends a high volume of
+    /// messages (especially multicast), and your application cannot process them fast enough,
+    /// leading to the kernel dropping messages. A larger buffer may help mitigate this.
+    ///
+    /// The value passed is a hint to the kernel to set the size of the receive buffer.
+    /// The kernel will double the value provided to account for bookkeeping overhead.
+    /// The doubled value is capped by the value in `/proc/sys/net/core/rmem_max`.
+    ///
+    /// The default value is `/proc/sys/net/core/rmem_default`
+    ///
+    /// See `socket(7)` documentation for `SO_RCVBUF` for more information.
+    pub fn set_recv_buffer_size(&self, size: usize) -> Result<(), SocketError> {
+        self.socket
+            .set_recv_buffer_size(size)
+            .map_err(SocketError::from)
+    }
+
     /// If [`true`] is passed in, enable extended ACKs for this socket. If [`false`]
     /// is passed in, disable extended ACKs for this socket.
     pub fn enable_ext_ack(&self, enable: bool) -> Result<(), SocketError> {


### PR DESCRIPTION
Closes #230 

I think that this was the intent of the issue author.
I've read a bit about the option, and it seems that we cannot rely on the kernel to set a specific size, so we cannot rely on that to simplify the logic in neli's buffers.

I didn't provide an option to set the send buffer size, because the default should be good enough (netlink isn't typically used to send large amounts of data).