### PR TITLE
Expand nl80211 example

### DIFF
--- a/examples/nl80211.rs
+++ b/examples/nl80211.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::{error::Error, iter::once};
 
 #[cfg(feature = "async")]
 use neli::router::asynchronous::NlRouter;
@@ -10,8 +10,10 @@ use neli::{
         nl::{GenlId, NlmF},
         socket::NlFamily,
     },
+    genl::{AttrTypeBuilder, NlattrBuilder},
     genl::{Genlmsghdr, GenlmsghdrBuilder, NoUserHeader},
     nl::{NlPayload, Nlmsghdr},
+    types::GenlBuffer,
     utils::Groups,
 };
 
@@ -19,6 +21,7 @@ use neli::{
 pub enum Nl80211Command {
     Unspecified = 0,
     GetWiPhy = 1,
+    GetInterface = 5,
     /* Many many more elided */
 }
 impl neli::consts::genl::Cmd for Nl80211Command {}
@@ -26,12 +29,25 @@ impl neli::consts::genl::Cmd for Nl80211Command {}
 #[neli::neli_enum(serialized_type = "u16")]
 pub enum Nl80211Attribute {
     Unspecified = 0,
-
     Wiphy = 1,
     WiphyName = 2,
+    Ifname = 4,
+    Iftype = 5,
+    Ssid = 52,
+    Wdev = 153,
     /* Literally hundreds elided */
 }
 impl neli::consts::genl::NlAttrType for Nl80211Attribute {}
+
+#[neli::neli_enum(serialized_type = "u32")]
+pub enum Nl80211IfType {
+    Unspecified = 0,
+    Station = 2,
+    Ap = 3,
+    Monitor = 6,
+    P2pDevice = 10,
+    /* Several more, common ones above */
+}
 
 fn handle(msg: Nlmsghdr<GenlId, Genlmsghdr<Nl80211Command, Nl80211Attribute>>) {
     // Messages with the NlmF::DUMP flag end with an empty payload message
@@ -52,6 +68,27 @@ fn handle(msg: Nlmsghdr<GenlId, Genlmsghdr<Nl80211Command, Nl80211Attribute>>) {
                 let wiphy_name = attr.get_payload_as_with_len::<String>().unwrap();
                 println!("{:<12}{}", "WiphyName:", wiphy_name);
             }
+            Nl80211Attribute::Ifname => {
+                let ifname = attr.get_payload_as_with_len::<String>().unwrap();
+                println!("{:<12}{}", "Ifname:", ifname);
+            }
+            Nl80211Attribute::Iftype => {
+                let iftype = attr.get_payload_as::<Nl80211IfType>().unwrap();
+                println!("{:<12}{:?}", "Iftype:", iftype);
+            }
+            Nl80211Attribute::Wdev => {
+                // Wdev is unique 64-bit identifier per WiFi interface containing both the
+                // WiFi radio (wiphy, upper 32 bits) and WiFi interface identifiers (lower 32 bits)
+                // Print lower 9 bytes (36 bits) to simplify printout and match 'iw wlan0 info' output
+                let wdev = attr.get_payload_as::<u64>().unwrap();
+                println!("{:<12}0x{:09x}", "Wdev:", wdev);
+            }
+            Nl80211Attribute::Ssid => {
+                // Kernel references this attribute as binary data.
+                // For simplicity, just try to parse as UTF-8
+                let ssid: &[u8] = attr.get_payload_as_with_len_borrowed().unwrap();
+                println!("{:<12}{}", "Ssid:", std::str::from_utf8(ssid).unwrap());
+            }
             _ => (),
         }
     }
@@ -62,6 +99,7 @@ fn handle(msg: Nlmsghdr<GenlId, Genlmsghdr<Nl80211Command, Nl80211Attribute>>) {
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
+    // Initialize NlRouter and resolve 'nl80211' genl family
     let (sock, _) = NlRouter::connect(
         NlFamily::Generic, /* family */
         Some(0),           /* pid */
@@ -70,6 +108,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .await?;
     let family_id = sock.resolve_genl_family("nl80211").await?;
 
+    // Query system for WiFi radios using the 'GetWiphy' command
     let mut recv = sock
         .send::<_, _, u16, Genlmsghdr<Nl80211Command, Nl80211Attribute>>(
             family_id,
@@ -83,9 +122,50 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .await?;
 
+    // Print response data which contains WiFi radios detected and configured by system
+    println!("WiFi radios:");
     while let Some(Ok(msg)) = recv.next().await {
         handle(msg);
+        println!();
     }
+
+    // Query system for WiFi interfaces using the 'GetInterface' command
+    // Empty payload for 'Ifname' attribute will dump all WiFi interfaces
+    let attrs = once(
+        NlattrBuilder::default()
+            .nla_type(
+                AttrTypeBuilder::default()
+                    .nla_type(Nl80211Attribute::Ifname)
+                    .build()
+                    .unwrap(),
+            )
+            .nla_payload(())
+            .build()
+            .unwrap(),
+    )
+    .collect::<GenlBuffer<_, _>>();
+
+    let mut recv = sock
+        .send::<_, _, u16, Genlmsghdr<Nl80211Command, Nl80211Attribute>>(
+            family_id,
+            NlmF::DUMP | NlmF::ACK,
+            NlPayload::Payload(
+                GenlmsghdrBuilder::<Nl80211Command, Nl80211Attribute, NoUserHeader>::default()
+                    .cmd(Nl80211Command::GetInterface)
+                    .attrs(attrs)
+                    .version(1)
+                    .build()?,
+            ),
+        )
+        .await?;
+
+    // Print response data which contains WiFi interfaces detected and configured by system
+    println!("WiFi interfaces:");
+    while let Some(Ok(msg)) = recv.next().await {
+        handle(msg);
+        println!();
+    }
+
     Ok(())
 }
 
@@ -93,6 +173,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
+    // Initialize NlRouter and resolve 'nl80211' genl family
     let (sock, _) = NlRouter::connect(
         NlFamily::Generic, /* family */
         Some(0),           /* pid */
@@ -100,6 +181,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     )?;
     let family_id = sock.resolve_genl_family("nl80211")?;
 
+    // Query system for WiFi radios using the 'GetWiphy' command
     let recv = sock.send(
         family_id,
         NlmF::DUMP | NlmF::ACK,
@@ -111,9 +193,49 @@ fn main() -> Result<(), Box<dyn Error>> {
         ),
     )?;
 
+    // Print response data which contains WiFi radios detected and configured by system
+    println!("WiFi radios:");
     for msg in recv {
         let msg = msg?;
         handle(msg);
+        println!();
     }
+
+    // Query system for WiFi interfaces using the 'GetInterface' command
+    // Empty payload for 'Ifname' attribute will dump all WiFi interfaces
+    let attrs = once(
+        NlattrBuilder::default()
+            .nla_type(
+                AttrTypeBuilder::default()
+                    .nla_type(Nl80211Attribute::Ifname)
+                    .build()
+                    .unwrap(),
+            )
+            .nla_payload(())
+            .build()
+            .unwrap(),
+    )
+    .collect::<GenlBuffer<_, _>>();
+
+    let recv = sock.send(
+        family_id,
+        NlmF::DUMP | NlmF::ACK,
+        NlPayload::Payload(
+            GenlmsghdrBuilder::<Nl80211Command, Nl80211Attribute, NoUserHeader>::default()
+                .cmd(Nl80211Command::GetInterface)
+                .attrs(attrs)
+                .version(1)
+                .build()?,
+        ),
+    )?;
+
+    // Print response data which contains WiFi interfaces detected and configured by system
+    println!("WiFi interfaces:");
+    for msg in recv {
+        let msg = msg?;
+        handle(msg);
+        println!();
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Expand the nl80211 example to include interface-level information printouts.

~~This is somewhat self-motivated, as I am having trouble with parsing the SSID field. Unlike interface and wiphy name attributes, the SSID is not NULL-terminated (note the partial SSID in the printout, should be `partialssid`). I'm sure with fresh eyes I can find it, but doesn't hurt to update the example haha!~~ See below comment on using `get_payload_as_with_len_borrowed()` with `&[u8]`.

Note that P2P device interfaces do not have an interface index or name when queried with `NL80211_CMD_GET_INTERFACE`, at least how I've updated the example.

```Bash
$ cargo run --example nl80211 --features async
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/examples/nl80211`
WiFi radios:
Wiphy:      0
WiphyName:  phy0


WiFi interfaces:
Wiphy:      0
Iftype:     P2pDevice
Wdev:       3

Ifname:     wlp3s0
Wiphy:      0
Iftype:     Station
Wdev:       1
Ssid:       partialssi
```