### PR TITLE
Remove unnecessary gnu feature gate from Ifa's Flags

### DIFF
--- a/src/consts/rtnl.rs
+++ b/src/consts/rtnl.rs
@@ -375,7 +375,6 @@ pub enum Ifa {
     Anycast = libc::IFA_ANYCAST,
     Cacheinfo = libc::IFA_CACHEINFO,
     Multicast = libc::IFA_MULTICAST,
-    #[cfg(target_env = "gnu")]
     Flags = libc::IFA_FLAGS,
 }
 


### PR DESCRIPTION
`IFA_FLAGS` can be found from `libc` without feature gate: 

https://github.com/rust-lang/libc/blob/a7fe341fbf1f6eeadbd74b4be35fca9c85c55563/src/unix/linux_like/linux/mod.rs#L2567

This change has been tested with musl libc.