### PR TITLE
Fix memory leak in router processing thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ optional = true
 
 [dependencies.tokio]
 version = "1"
-features = ["io-util", "net", "sync", "rt"]
+features = ["io-util", "net", "sync", "rt", "macros"]
 optional = true
 
 [dev-dependencies]

--- a/examples/ctrl-list-multiple.rs
+++ b/examples/ctrl-list-multiple.rs
@@ -1,0 +1,122 @@
+use std::{env, error::Error};
+
+#[cfg(feature = "async")]
+use tokio::runtime::Runtime;
+
+#[cfg(feature = "async")]
+use neli::router::asynchronous::NlRouter;
+#[cfg(not(feature = "async"))]
+use neli::router::synchronous::NlRouter;
+use neli::{
+    attr::Attribute,
+    consts::{genl::*, nl::*, socket::*},
+    genl::{Genlmsghdr, GenlmsghdrBuilder},
+    nl::NlPayload,
+    types::{Buffer, GenlBuffer},
+    utils::Groups,
+};
+
+const GENL_VERSION: u8 = 2;
+
+// This example attempts to mimic the "genl ctrl list" command. For simplicity, it only outputs
+// the name and identifier of each generic netlink family.
+
+#[cfg(feature = "async")]
+fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    let num_reps = env::args()
+        .nth(1)
+        .ok_or("Number of loop repetitions required")?
+        .parse::<usize>()?;
+
+    Runtime::new()?.block_on(async {
+        for _ in 0..num_reps {
+            let (socket, _) = NlRouter::connect(NlFamily::Generic, None, Groups::empty()).await?;
+            let mut recv = socket
+                .send::<_, _, NlTypeWrapper, Genlmsghdr<CtrlCmd, CtrlAttr>>(
+                    GenlId::Ctrl,
+                    NlmF::DUMP,
+                    NlPayload::Payload(
+                        GenlmsghdrBuilder::default()
+                            .cmd(CtrlCmd::Getfamily)
+                            .version(GENL_VERSION)
+                            .attrs(GenlBuffer::<u16, Buffer>::new())
+                            .build()?,
+                    ),
+                )
+                .await?;
+
+            while let Some(response_result) = recv
+                .next::<NlTypeWrapper, Genlmsghdr<CtrlCmd, CtrlAttr>>()
+                .await
+            {
+                let response = response_result?;
+
+                if let Some(p) = response.get_payload() {
+                    let handle = p.attrs().get_attr_handle();
+                    for attr in handle.iter() {
+                        match attr.nla_type().nla_type() {
+                            CtrlAttr::FamilyName => {
+                                println!("{}", attr.get_payload_as_with_len::<String>()?);
+                            }
+                            CtrlAttr::FamilyId => {
+                                println!("\tID: 0x{:x}", attr.get_payload_as::<u16>()?);
+                            }
+                            _ => (),
+                        }
+                    }
+                }
+            }
+        }
+        Result::<_, Box<dyn Error>>::Ok(())
+    })?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "async"))]
+fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    let num_reps = env::args()
+        .nth(1)
+        .ok_or_else(|| "Number of loop repetitions required")?
+        .parse::<usize>()?;
+
+    for _ in 0..num_reps {
+        let (socket, _) = NlRouter::connect(NlFamily::Generic, None, Groups::empty())?;
+        let recv = socket.send::<_, _, NlTypeWrapper, Genlmsghdr<CtrlCmd, CtrlAttr>>(
+            GenlId::Ctrl,
+            NlmF::DUMP,
+            NlPayload::Payload(
+                GenlmsghdrBuilder::default()
+                    .cmd(CtrlCmd::Getfamily)
+                    .version(GENL_VERSION)
+                    .attrs(GenlBuffer::<u16, Buffer>::new())
+                    .build()?,
+            ),
+        )?;
+
+        for response_result in recv {
+            let response = response_result?;
+
+            if let Some(p) = response.get_payload() {
+                let handle = p.attrs().get_attr_handle();
+                for attr in handle.iter() {
+                    match attr.nla_type().nla_type() {
+                        CtrlAttr::FamilyName => {
+                            println!("{}", attr.get_payload_as_with_len::<String>()?);
+                        }
+                        CtrlAttr::FamilyId => {
+                            println!("\tID: 0x{:x}", attr.get_payload_as::<u16>()?);
+                        }
+                        _ => (),
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/error_packet.rs
+++ b/examples/error_packet.rs
@@ -5,6 +5,8 @@ use neli::{
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
     // Create a socket and connect to generic netlink.
     let (sock, _) = NlRouter::connect(NlFamily::Generic, None, Groups::empty())?;
     // Attempt to resolve a multicast group that should not exist.
@@ -15,7 +17,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             // Should be packet that caused error
             println!("{e:?}");
         }
-        Err(_) => panic!("Should not return any error other than NlError"),
+        Err(e) => panic!("Should not return any error other than NlError: {e}"),
     };
     Ok(())
 }

--- a/src/router/asynchronous.rs
+++ b/src/router/asynchronous.rs
@@ -7,9 +7,9 @@ use std::{
 
 use log::{error, trace, warn};
 use tokio::{
-    spawn,
+    select, spawn,
     sync::{
-        mpsc::{channel, error::TryRecvError, Receiver, Sender},
+        mpsc::{channel, Receiver, Sender},
         Mutex,
     },
 };
@@ -20,7 +20,7 @@ use crate::{
         nl::{GenlId, NlType, NlmF, Nlmsg},
         socket::NlFamily,
     },
-    err::RouterError,
+    err::{RouterError, SocketError},
     genl::{AttrTypeBuilder, Genlmsghdr, GenlmsghdrBuilder, NlattrBuilder, NoUserHeader},
     nl::{NlPayload, Nlmsghdr, NlmsghdrBuilder},
     socket::asynchronous::NlSocketHandle,
@@ -33,6 +33,7 @@ type GenlFamily = Result<
     NlBuffer<GenlId, Genlmsghdr<CtrlCmd, CtrlAttr>>,
     RouterError<GenlId, Genlmsghdr<CtrlCmd, CtrlAttr>>,
 >;
+type MCastSender = Sender<Result<Nlmsghdr<u16, Buffer>, RouterError<u16, Buffer>>>;
 type Senders =
     Arc<Mutex<HashMap<u32, Sender<Result<Nlmsghdr<u16, Buffer>, RouterError<u16, Buffer>>>>>>;
 type ProcThreadReturn = (
@@ -50,82 +51,99 @@ pub struct NlRouter {
     exit_sender: Sender<()>,
 }
 
+async fn processing_loop(
+    socket: &Arc<NlSocketHandle>,
+    senders: &Senders,
+    multicast_sender: &MCastSender,
+    iter: impl Iterator<Item = Result<Nlmsghdr<u16, Buffer>, SocketError>>,
+    group: Groups,
+) {
+    for msg in iter {
+        trace!("Message received: {msg:?}");
+        let mut seqs_to_remove = HashSet::new();
+        match msg {
+            Ok(m) => {
+                let seq = *m.nl_seq();
+                let lock = senders.lock().await;
+                if !group.is_empty() {
+                    if multicast_sender.send(Ok(m)).await.is_err() {
+                        warn!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                    }
+                } else if let Some(sender) = lock.get(m.nl_seq()) {
+                    if &socket.pid() == m.nl_pid() {
+                        if sender.send(Ok(m)).await.is_err() {
+                            error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                            seqs_to_remove.insert(seq);
+                        }
+                    } else {
+                        for (seq, sender) in lock.iter() {
+                            if sender
+                                .send(Err(RouterError::BadSeqOrPid(m.clone())))
+                                .await
+                                .is_err()
+                            {
+                                error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                                seqs_to_remove.insert(*seq);
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                let lock = senders.lock().await;
+                for (seq, sender) in lock.iter() {
+                    if sender
+                        .send(Err(RouterError::from(e.clone())))
+                        .await
+                        .is_err()
+                    {
+                        error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                        seqs_to_remove.insert(*seq);
+                    }
+                }
+            }
+        }
+        for seq in seqs_to_remove {
+            senders.lock().await.remove(&seq);
+        }
+    }
+}
+
 fn spawn_processing_thread(socket: Arc<NlSocketHandle>, senders: Senders) -> ProcThreadReturn {
     let (exit_sender, mut exit_receiver) = channel(1);
     let (multicast_sender, multicast_receiver) = channel(1024);
     spawn(async move {
-        while let Err(TryRecvError::Empty) = exit_receiver.try_recv() {
-            match socket.recv::<u16, Buffer>().await {
-                Ok((iter, group)) => {
-                    for msg in iter {
-                        trace!("Message received: {msg:?}");
-                        let mut seqs_to_remove = HashSet::new();
-                        match msg {
-                            Ok(m) => {
-                                let seq = *m.nl_seq();
-                                let lock = senders.lock().await;
-                                if !group.is_empty() {
-                                    if multicast_sender.send(Ok(m)).await.is_err() {
-                                        warn!("{}", RouterError::<u16, Buffer>::ClosedChannel);
-                                    }
-                                } else if let Some(sender) = lock.get(m.nl_seq()) {
-                                    if &socket.pid() == m.nl_pid() {
-                                        if sender.send(Ok(m)).await.is_err() {
-                                            error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
-                                            seqs_to_remove.insert(seq);
-                                        }
-                                    } else {
-                                        for (seq, sender) in lock.iter() {
-                                            if sender
-                                                .send(Err(RouterError::BadSeqOrPid(m.clone())))
-                                                .await
-                                                .is_err()
-                                            {
-                                                error!(
-                                                    "{}",
-                                                    RouterError::<u16, Buffer>::ClosedChannel
-                                                );
-                                                seqs_to_remove.insert(*seq);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                let lock = senders.lock().await;
-                                for (seq, sender) in lock.iter() {
-                                    if sender
-                                        .send(Err(RouterError::from(e.clone())))
-                                        .await
-                                        .is_err()
-                                    {
-                                        error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
-                                        seqs_to_remove.insert(*seq);
-                                    }
-                                }
-                            }
-                        }
-                        for seq in seqs_to_remove {
-                            senders.lock().await.remove(&seq);
-                        }
+        loop {
+            select! {
+                res = exit_receiver.recv() => {
+                    if res.is_none() {
+                        warn!("Failed to read from exit channel");
                     }
+                    return;
                 }
-                Err(e) => {
-                    let mut seqs_to_remove = HashSet::new();
-                    let mut lock = senders.lock().await;
-                    for (seq, sender) in lock.iter() {
-                        if sender
-                            .send(Err(RouterError::from(e.clone())))
-                            .await
-                            .is_err()
-                        {
-                            seqs_to_remove.insert(*seq);
-                            error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
-                            break;
+                res = socket.recv::<u16, Buffer>() => {
+                    match res {
+                        Ok((iter, group)) => {
+                            processing_loop(&socket, &senders, &multicast_sender, iter, group).await
                         }
-                    }
-                    for seq in seqs_to_remove {
-                        lock.remove(&seq);
+                        Err(e) => {
+                            let mut seqs_to_remove = HashSet::new();
+                            let mut lock = senders.lock().await;
+                            for (seq, sender) in lock.iter() {
+                                if sender
+                                    .send(Err(RouterError::from(e.clone())))
+                                    .await
+                                    .is_err()
+                                {
+                                    seqs_to_remove.insert(*seq);
+                                    error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                                    break;
+                                }
+                            }
+                            for seq in seqs_to_remove {
+                                lock.remove(&seq);
+                            }
+                        }
                     }
                 }
             }

--- a/src/router/synchronous.rs
+++ b/src/router/synchronous.rs
@@ -1,15 +1,18 @@
 use std::{
     collections::{HashMap, HashSet},
+    io,
     iter::once,
     marker::PhantomData,
+    mem::MaybeUninit,
+    os::fd::{AsRawFd, FromRawFd, OwnedFd},
     sync::{
-        mpsc::{channel, Receiver, Sender, TryRecvError},
+        mpsc::{channel, Receiver, Sender},
         Arc,
     },
     thread::spawn,
 };
 
-use log::{error, trace, warn};
+use log::{debug, error, trace, warn};
 use parking_lot::Mutex;
 
 use crate::{
@@ -18,7 +21,7 @@ use crate::{
         nl::{GenlId, NlType, NlmF, Nlmsg},
         socket::NlFamily,
     },
-    err::RouterError,
+    err::{RouterError, SocketError},
     genl::{AttrTypeBuilder, Genlmsghdr, GenlmsghdrBuilder, NlattrBuilder, NoUserHeader},
     nl::{NlPayload, Nlmsghdr, NlmsghdrBuilder},
     socket::synchronous::NlSocketHandle,
@@ -31,6 +34,7 @@ type GenlFamily = Result<
     NlBuffer<GenlId, Genlmsghdr<CtrlCmd, CtrlAttr>>,
     RouterError<GenlId, Genlmsghdr<CtrlCmd, CtrlAttr>>,
 >;
+type MCastSender = Sender<Result<Nlmsghdr<u16, Buffer>, RouterError<u16, Buffer>>>;
 type Senders =
     Arc<Mutex<HashMap<u32, Sender<Result<Nlmsghdr<u16, Buffer>, RouterError<u16, Buffer>>>>>>;
 type ConnectReturn<T> = Result<
@@ -40,10 +44,13 @@ type ConnectReturn<T> = Result<
     ),
     RouterError<u16, Buffer>,
 >;
-type ProcThreadReturn = (
-    Sender<()>,
-    Receiver<Result<Nlmsghdr<u16, Buffer>, RouterError<u16, Buffer>>>,
-);
+type ProcThreadReturn = Result<
+    (
+        Receiver<Result<Nlmsghdr<u16, Buffer>, RouterError<u16, Buffer>>>,
+        OwnedFd,
+    ),
+    RouterError<u16, Buffer>,
+>;
 
 /// A high-level handle for sending messages and generating a handle that validates
 /// all of the received messages.
@@ -51,92 +58,204 @@ pub struct NlRouter {
     socket: Arc<NlSocketHandle>,
     seq: Mutex<u32>,
     senders: Senders,
-    exit_sender: Sender<()>,
+    fd: OwnedFd,
 }
 
-fn spawn_processing_thread(socket: Arc<NlSocketHandle>, senders: Senders) -> ProcThreadReturn {
-    let (exit_sender, exit_receiver) = channel();
-    let (multicast_sender, multicast_receiver) = channel();
-    spawn(move || {
-        while let Err(TryRecvError::Empty) = exit_receiver.try_recv() {
-            match socket.recv::<u16, Buffer>() {
-                Ok((iter, group)) => {
-                    for msg in iter {
-                        trace!("Message received: {msg:?}");
-                        let mut seqs_to_remove = HashSet::new();
-                        match msg {
-                            Ok(m) => {
-                                let seq = *m.nl_seq();
-                                let lock = senders.lock();
-                                if !group.is_empty() {
-                                    if multicast_sender.send(Ok(m)).is_err() {
-                                        warn!("{}", RouterError::<u16, Buffer>::ClosedChannel);
-                                    }
-                                } else if let Some(sender) = lock.get(m.nl_seq()) {
-                                    if &socket.pid() == m.nl_pid() {
-                                        if sender.send(Ok(m)).is_err() {
-                                            error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
-                                            seqs_to_remove.insert(seq);
-                                        }
-                                    } else {
-                                        for (seq, sender) in lock.iter() {
-                                            if sender
-                                                .send(Err(RouterError::BadSeqOrPid(m.clone())))
-                                                .is_err()
-                                            {
-                                                error!(
-                                                    "{}",
-                                                    RouterError::<u16, Buffer>::ClosedChannel
-                                                );
-                                                seqs_to_remove.insert(*seq);
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    for (seq, sender) in lock.iter() {
-                                        if sender
-                                            .send(Err(RouterError::BadSeqOrPid(m.clone())))
-                                            .is_err()
-                                        {
-                                            error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
-                                            seqs_to_remove.insert(*seq);
-                                        }
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                let lock = senders.lock();
-                                for (seq, sender) in lock.iter() {
-                                    if sender.send(Err(RouterError::from(e.clone()))).is_err() {
-                                        error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
-                                        seqs_to_remove.insert(*seq);
-                                    }
-                                }
+fn processing_loop(
+    socket: &Arc<NlSocketHandle>,
+    senders: &Senders,
+    multicast_sender: &MCastSender,
+    iter: impl Iterator<Item = Result<Nlmsghdr<u16, Buffer>, SocketError>>,
+    group: Groups,
+) {
+    for msg in iter {
+        trace!("Message received: {msg:?}");
+        let mut seqs_to_remove = HashSet::new();
+        match msg {
+            Ok(m) => {
+                let seq = *m.nl_seq();
+                let lock = senders.lock();
+                if !group.is_empty() {
+                    if multicast_sender.send(Ok(m)).is_err() {
+                        warn!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                    }
+                } else if let Some(sender) = lock.get(m.nl_seq()) {
+                    if &socket.pid() == m.nl_pid() {
+                        if sender.send(Ok(m)).is_err() {
+                            error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                            seqs_to_remove.insert(seq);
+                        }
+                    } else {
+                        for (seq, sender) in lock.iter() {
+                            if sender
+                                .send(Err(RouterError::BadSeqOrPid(m.clone())))
+                                .is_err()
+                            {
+                                error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                                seqs_to_remove.insert(*seq);
                             }
                         }
-                        for seq in seqs_to_remove {
-                            senders.lock().remove(&seq);
+                    }
+                } else {
+                    for (seq, sender) in lock.iter() {
+                        if sender
+                            .send(Err(RouterError::BadSeqOrPid(m.clone())))
+                            .is_err()
+                        {
+                            error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                            seqs_to_remove.insert(*seq);
                         }
                     }
                 }
-                Err(e) => {
-                    let mut seqs_to_remove = HashSet::new();
-                    let mut lock = senders.lock();
-                    for (seq, sender) in lock.iter() {
-                        if sender.send(Err(RouterError::from(e.clone()))).is_err() {
-                            seqs_to_remove.insert(*seq);
-                            error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
-                            break;
+            }
+            Err(e) => {
+                let lock = senders.lock();
+                for (seq, sender) in lock.iter() {
+                    if sender.send(Err(RouterError::from(e.clone()))).is_err() {
+                        error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+                        seqs_to_remove.insert(*seq);
+                    }
+                }
+            }
+        }
+        for seq in seqs_to_remove {
+            senders.lock().remove(&seq);
+        }
+    }
+}
+
+fn error_handling(senders: &Senders, e: SocketError) {
+    let mut seqs_to_remove = HashSet::new();
+    let mut lock = senders.lock();
+    for (seq, sender) in lock.iter() {
+        if sender.send(Err(RouterError::from(e.clone()))).is_err() {
+            seqs_to_remove.insert(*seq);
+            error!("{}", RouterError::<u16, Buffer>::ClosedChannel);
+            break;
+        }
+    }
+    for seq in seqs_to_remove {
+        lock.remove(&seq);
+    }
+}
+
+fn spawn_processing_thread(socket: Arc<NlSocketHandle>, senders: Senders) -> ProcThreadReturn {
+    let owned_event_fd = {
+        let event_fd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+        if event_fd < 0 {
+            return Err(RouterError::new(format!(
+                "Failed to initialize eventfd for signaling processing thread exit: errno {event_fd}"
+            )));
+        }
+        unsafe { OwnedFd::from_raw_fd(event_fd) }
+    };
+
+    let owned_duped_event_fd = {
+        let duped_event_fd = unsafe { libc::dup(owned_event_fd.as_raw_fd()) };
+        if duped_event_fd < 0 {
+            return Err(RouterError::new(format!(
+                "Failed to duplicate eventfd for signaling processing thread exit: errno {duped_event_fd}"
+            )));
+        }
+        unsafe { OwnedFd::from_raw_fd(duped_event_fd) }
+    };
+
+    socket.set_nonblock()?;
+
+    let epoll_fd = unsafe { libc::epoll_create(1) };
+    if epoll_fd < 0 {
+        return Err(RouterError::Io(
+            io::Error::from_raw_os_error(epoll_fd).kind(),
+        ));
+    }
+    let epoll = unsafe { OwnedFd::from_raw_fd(epoll_fd) };
+
+    let (multicast_sender, multicast_receiver) = channel();
+    spawn(move || {
+        const EVENT_FD_TOKEN: u64 = 0;
+        const SOCKET_TOKEN: u64 = 1;
+
+        let mut event_fd_epoll_event = libc::epoll_event {
+            events: libc::EPOLLIN as u32,
+            u64: EVENT_FD_TOKEN,
+        };
+        unsafe {
+            libc::epoll_ctl(
+                epoll_fd.as_raw_fd(),
+                libc::EPOLL_CTL_ADD,
+                owned_event_fd.as_raw_fd(),
+                &mut event_fd_epoll_event as *mut _,
+            )
+        };
+        let mut socket_epoll_event = libc::epoll_event {
+            events: libc::EPOLLIN as u32,
+            u64: SOCKET_TOKEN,
+        };
+        unsafe {
+            libc::epoll_ctl(
+                epoll_fd.as_raw_fd(),
+                libc::EPOLL_CTL_ADD,
+                socket.as_raw_fd(),
+                &mut socket_epoll_event as *mut _,
+            )
+        };
+
+        let mut events = vec![MaybeUninit::<libc::epoll_event>::uninit(); 2];
+        loop {
+            let event_count = unsafe {
+                libc::epoll_wait(
+                    epoll.as_raw_fd(),
+                    events.as_mut_ptr() as *mut _,
+                    events.len() as libc::c_int,
+                    100, /* ms */
+                )
+            };
+            if event_count < 0 {
+                warn!(
+                    "Failed to epoll file descriptors: errno {event_count}; exiting processing thread"
+                );
+                return;
+            }
+            for event in events.iter().take(event_count as usize) {
+                if unsafe { event.assume_init_ref() }.u64 == EVENT_FD_TOKEN {
+                    let mut buffer = [0u8; 8];
+                    let ret = unsafe {
+                        libc::read(
+                            owned_event_fd.as_raw_fd(),
+                            buffer.as_mut_ptr() as *mut _,
+                            buffer.len(),
+                        )
+                    };
+                    match ret as i32 {
+                        i if i > 0 => {
+                            debug!("Processing thread signaled to exit; exiting");
+                            return;
+                        }
+                        libc::EAGAIN => (),
+                        i => {
+                            warn!("Unexpected return value from read: {i}");
                         }
                     }
-                    for seq in seqs_to_remove {
-                        lock.remove(&seq);
+                } else if unsafe { event.assume_init_ref() }.u64 == SOCKET_TOKEN {
+                    match socket.recv::<u16, Buffer>() {
+                        Ok((iter, group)) => {
+                            processing_loop(&socket, &senders, &multicast_sender, iter, group)
+                        }
+                        Err(e) => {
+                            if let SocketError::Io(ref io_e) = e {
+                                if io_e.kind() != io::ErrorKind::WouldBlock {
+                                    error_handling(&senders, e);
+                                }
+                            } else {
+                                error_handling(&senders, e);
+                            }
+                        }
                     }
                 }
             }
         }
     });
-    (exit_sender, multicast_receiver)
+    Ok((multicast_receiver, owned_duped_event_fd))
 }
 
 impl NlRouter {
@@ -144,8 +263,8 @@ impl NlRouter {
     pub fn connect(proto: NlFamily, pid: Option<u32>, groups: Groups) -> ConnectReturn<Self> {
         let socket = Arc::new(NlSocketHandle::connect(proto, pid, groups)?);
         let senders = Arc::new(Mutex::new(HashMap::default()));
-        let (exit_sender, multicast_receiver) =
-            spawn_processing_thread(Arc::clone(&socket), Arc::clone(&senders));
+        let (multicast_receiver, fd) =
+            spawn_processing_thread(Arc::clone(&socket), Arc::clone(&senders))?;
         let multicast_receiver =
             NlRouterReceiverHandle::new(multicast_receiver, Arc::clone(&senders), false, None);
         Ok((
@@ -153,7 +272,7 @@ impl NlRouter {
                 socket,
                 senders,
                 seq: Mutex::new(0),
-                exit_sender,
+                fd,
             },
             multicast_receiver,
         ))
@@ -288,7 +407,7 @@ impl NlRouter {
 
         let mut buffer = NlBuffer::new();
         for msg in recv {
-            buffer.push(msg?);
+            buffer.push(msg?)
         }
         Ok(buffer)
     }
@@ -404,8 +523,16 @@ impl NlRouter {
 
 impl Drop for NlRouter {
     fn drop(&mut self) {
-        if self.exit_sender.send(()).is_err() {
-            warn!("Failed to send shutdown message; processing thread should exit anyway");
+        let buffer: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 1];
+        let ret = unsafe {
+            libc::write(
+                self.fd.as_raw_fd(),
+                buffer.as_ptr() as *const _,
+                buffer.len(),
+            )
+        };
+        if ret < 0 {
+            warn!("Failed to signal processing thread to exit: errno {ret}");
         }
     }
 }

--- a/src/socket/synchronous.rs
+++ b/src/socket/synchronous.rs
@@ -181,6 +181,10 @@ impl NlSocketHandle {
             .get_strict_checking_enabled()
             .map_err(SocketError::from)
     }
+
+    pub(in super::super) fn set_nonblock(&self) -> Result<(), SocketError> {
+        self.socket.nonblock().map_err(SocketError::from)
+    }
 }
 
 impl AsRawFd for NlSocketHandle {


### PR DESCRIPTION
Closes #308 

When dropped, NlRouter would not shut down the thread. This resulted in what is effectively a memory leak with threads hanging around and never being cleaned up.

This change provides fixes for both the synchronous and asynchronous variants, waiting on both the socket for input and the exit notifier to avoid this problem.

I believe I've confirmed both the original problem and resolved it with the PR.